### PR TITLE
Add new USDZ export option

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "style-loader": "^1.3.0",
     "styled-components": "^5.2.1",
     "svgtodatauri": "0.0.0",
-    "three": "^0.115.0",
+    "three": "^0.125.0",
     "ts-debounce": "^2.1.0",
     "use-deep-compare-effect": "^1.6.1",
     "utils": "^0.3.1",

--- a/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
+++ b/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
@@ -33,6 +33,7 @@ import toDataUrl from 'svgtodatauri';
 import * as THREE from 'three';
 import { Quaternion, Vector3, WebGLRenderer } from 'three';
 import { ColladaExporter } from 'three/examples/jsm/exporters/ColladaExporter';
+import { USDZExporter } from 'three/examples/jsm/exporters/USDZExporter.js';
 import { Action } from '../utils';
 
 /**
@@ -218,7 +219,7 @@ export const CrystalToolkitScene: React.FC<Props> = ({
   };
 
   /**
-   * Handle saving image to collada file (.dae)
+   * Handle saving image to Collada file (.dae)
    * Set imageData prop to data uri
    */
   const setColladaData = (sceneComponent: Scene) => {
@@ -235,6 +236,17 @@ export const CrystalToolkitScene: React.FC<Props> = ({
     props.setProps({ imageData, imageDataTimestamp });
   };
 
+  /**
+   * Handle saving scene to a Universal Scene Description
+   * (.usdz) file
+   */
+  const setUsdzData = (sceneComponent: Scene) => {
+    const files = new USDZExporter().parse(sceneComponent.scene, { binary: true });
+    const imageData = 'data:application/octet-stream;base64,' + btoa(files.data);
+    const imageDataTimestamp = Date.now();
+    props.setProps({ imageData, imageDataTimestamp });
+  };
+
   const requestImage = (filetype: ExportType, sceneComponent: Scene) => {
     // force a render (in case buffer has been cleared)
     switch (filetype) {
@@ -243,6 +255,9 @@ export const CrystalToolkitScene: React.FC<Props> = ({
         break;
       case ExportType.dae:
         setColladaData(sceneComponent);
+        break;
+      case ExportType.usdz:
+        setUsdzData(sceneComponent);
         break;
       default:
         throw new Error('Unknown filetype.');

--- a/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
+++ b/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
@@ -242,7 +242,7 @@ export const CrystalToolkitScene: React.FC<Props> = ({
    */
   const setUsdzData = (sceneComponent: Scene) => {
     const files = new USDZExporter().parse(sceneComponent.scene, { binary: true });
-    const imageData = 'data:application/octet-stream;base64,' + btoa(files.data);
+    const imageData = 'data:application/octet-stream;base64,' + btoa(files);
     const imageDataTimestamp = Date.now();
     props.setProps({ imageData, imageDataTimestamp });
   };

--- a/src/components/crystal-toolkit/scene/constants.ts
+++ b/src/components/crystal-toolkit/scene/constants.ts
@@ -6,6 +6,7 @@ export enum Renderer {
 export enum ExportType {
   png = 'png',
   dae = 'dae',
+  usdz = 'usdz',
 }
 
 export enum Material {


### PR DESCRIPTION
Have not tested, following previous example. Exporter seems to follow Three.js standard (like Collada), though return MIME type looks like it's `application/octet-stream` rather than `text/plain`.