### PR TITLE
Add props to support decoupling of materials input types and data fields

### DIFF
--- a/src/components/search/MaterialsInput/MaterialsInput.tsx
+++ b/src/components/search/MaterialsInput/MaterialsInput.tsx
@@ -14,6 +14,7 @@ import { PeriodicTableFormulaButtons } from '../../periodic-table/PeriodicTableF
 import './MaterialsInput.css';
 import { PeriodicTableModeSwitcher } from '../../periodic-table/PeriodicTableModeSwitcher';
 import { PeriodicTablePluginWrapper } from '../../periodic-table/PeriodicTablePluginWrapper';
+import { MaterialsInputTypesMap } from './utils';
 
 /**
  * An input field component for searching by mp-id, elements, or formula.
@@ -29,20 +30,21 @@ import { PeriodicTablePluginWrapper } from '../../periodic-table/PeriodicTablePl
  */
 export enum MaterialsInputType {
   ELEMENTS = 'elements',
-  EXCLUDE_ELEMENTS = 'exclude_elements',
-  ABSORBING_ELEMENT = 'absorbing_element',
   FORMULA = 'formula',
-  MP_ID = 'mp_id',
+  MPID = 'mpid',
   SMILES = 'smiles',
+  TEXT = 'text',
 }
 
 export interface MaterialsInputSharedProps {
   value: string;
   inputType: MaterialsInputType;
+  allowedInputTypes?: MaterialsInputType[];
   showInputTypeDropdown?: boolean;
   isChemSys?: boolean;
   allowSmiles?: boolean;
   placeholder?: string;
+  errorMessage?: string;
   onInputTypeChange?: (inputType: MaterialsInputType) => void;
 }
 
@@ -64,7 +66,16 @@ interface FormulaSuggestion {
 
 let requestCount = 0;
 
-export const MaterialsInput: React.FC<MaterialsInputProps> = (props) => {
+export const MaterialsInput: React.FC<MaterialsInputProps> = ({
+  errorMessage = 'Invalid input value',
+  allowedInputTypes = [
+    'elements' as MaterialsInputType,
+    'formula' as MaterialsInputType,
+    'mpid' as MaterialsInputType,
+  ],
+  ...otherProps
+}) => {
+  const props = { errorMessage, allowedInputTypes, ...otherProps };
   const [inputValue, setInputValue] = useState(props.value);
   const [inputType, setInputType] = useState(props.inputType);
   const debouncedInputValue = props.debounce ? useDebounce(inputValue, props.debounce) : inputValue;
@@ -183,6 +194,7 @@ export const MaterialsInput: React.FC<MaterialsInputProps> = (props) => {
     <MaterialsInputBox
       value={inputValue}
       inputType={inputType}
+      allowedInputTypes={props.allowedInputTypes}
       isChemSys={props.isChemSys}
       allowSmiles={props.allowSmiles}
       setValue={setInputValue}
@@ -193,7 +205,7 @@ export const MaterialsInput: React.FC<MaterialsInputProps> = (props) => {
       liftInputRef={(ref) => setInputRef(ref)}
       showInputTypeDropdown={props.showInputTypeDropdown}
       placeholder={props.placeholder}
-      error={error}
+      errorMessage={props.errorMessage}
       setError={setError}
     />
   );

--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -6,6 +6,8 @@ import { Column, FilterGroup, ConditionalRowStyle } from './types';
 import { SearchUISearchBar } from './SearchUISearchBar';
 import './SearchUI.css';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { MaterialsInputType } from '../MaterialsInput';
+import { MaterialsInputTypesMap } from '../MaterialsInput/utils';
 
 /**
  * Component for rendering advanced search interfaces for data in an API
@@ -133,6 +135,32 @@ export interface SearchUIProps {
   searchBarPlaceholder?: string;
 
   /**
+   * Custom error message to display with the top-level search bar
+   * if the user types an invalid value
+   */
+  searchBarErrorMessage?: string;
+
+  /**
+   * Object with keys of allowed input types for the top-level search bar.
+   * Keys must be one of these supported input types: "elements", "formula", "mpid", "smiles", "text"
+   * Each key object must have a "field" property which maps the input type
+   * to a valid data filter field in the API.
+   * e.g.
+    {
+      formula: {
+        field: 'formula'
+      },
+      elements: {
+        field: 'elements'
+      },
+      mpid: {
+        field: 'material_ids'
+      }
+    }
+   */
+  searchBarAllowedInputTypesMap?: MaterialsInputTypesMap;
+
+  /**
    * Optionally include a field to sort by on initial load
    * Must be a valid field and included in your list of columns
    */
@@ -180,10 +208,28 @@ export const SearchUI: React.FC<SearchUIProps> = ({
   resultLabel = 'results',
   hasSearchBar = true,
   conditionalRowStyles = [],
+  searchBarAllowedInputTypesMap = {
+    formula: {
+      field: 'formula',
+    },
+    elements: {
+      field: 'elements',
+    },
+    mpid: {
+      field: 'material_ids',
+    },
+  },
   setProps = () => null,
   ...otherProps
 }) => {
-  let props = { resultLabel, hasSearchBar, conditionalRowStyles, setProps, ...otherProps };
+  let props = {
+    resultLabel,
+    hasSearchBar,
+    conditionalRowStyles,
+    searchBarAllowedInputTypesMap,
+    setProps,
+    ...otherProps,
+  };
   return (
     <div id={props.id} className="mpc-search-ui">
       <Router>
@@ -193,7 +239,10 @@ export const SearchUI: React.FC<SearchUIProps> = ({
               {props.hasSearchBar && (
                 <div className="columns mb-1">
                   <div className="column pb-2">
-                    <SearchUISearchBar />
+                    <SearchUISearchBar
+                      allowedInputTypesMap={props.searchBarAllowedInputTypesMap}
+                      errorMessage={props.searchBarErrorMessage}
+                    />
                   </div>
                 </div>
               )}

--- a/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -79,11 +79,12 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
     },
     setFilterWithOverrides: (value: any, id: string, overrideFields: string[]) => {
       setState((currentState) => {
-        let newFilterValues = { [id]: value };
+        let newFilterValues = {};
         overrideFields.forEach((field) => {
           const activeFilter = currentState.activeFilters.find((a) => a.id === field);
           if (activeFilter) newFilterValues[field] = activeFilter.defaultValue;
         });
+        newFilterValues[id] = value;
         let newFilterGroups = currentState.filterGroups.slice();
         if (isDesktop) {
           newFilterGroups[0].expanded = true;

--- a/src/components/search/SearchUI/SearchUISearchBar/SearchUISearchBar.tsx
+++ b/src/components/search/SearchUI/SearchUISearchBar/SearchUISearchBar.tsx
@@ -3,6 +3,8 @@ import { MaterialsInput } from '../../MaterialsInput';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
 import { MaterialsInputType } from '../../MaterialsInput';
 import { Filter } from '../types';
+import { MaterialsInputTypesMap } from '../../MaterialsInput/utils';
+import { convertMaterialsInputTypesMapToArray } from '../utils';
 
 /**
  * A specific version of the MaterialsInput component used within the SearchUI component
@@ -10,7 +12,12 @@ import { Filter } from '../types';
  * The input value is parsed into its appropriate search field upon submission.
  */
 
-export const SearchUISearchBar: React.FC = () => {
+interface Props {
+  allowedInputTypesMap: MaterialsInputTypesMap;
+  errorMessage?: string;
+}
+
+export const SearchUISearchBar: React.FC<Props> = (props) => {
   const actions = useSearchUIContextActions();
   const state = useSearchUIContext();
   const [searchValue, setSearchValue] = useState<string>('');
@@ -28,33 +35,14 @@ export const SearchUISearchBar: React.FC = () => {
     }
   };
 
-  const getFieldsToOverride = (selectedField: string) => {
-    let fields: string[] = [];
-    state.filterGroups.forEach((g) => {
-      g.filters.forEach((f) => {
-        if (f.id !== selectedField && (f.type === 'MATERIALS_INPUT' || f.id === 'smiles')) {
-          fields.push(f.id);
-        }
-      });
-    });
-    return fields;
-  };
-
   const handleSubmit = (e: React.FormEvent | React.MouseEvent, value?: string) => {
-    let searchField = searchInputType as string;
-    if (searchInputType === MaterialsInputType.MP_ID) {
-      let mpIdFilter: Filter | undefined;
-      state.filterGroups.forEach((g) => {
-        if (!mpIdFilter) {
-          mpIdFilter = g.filters.find((f) => {
-            return f.type === 'MATERIALS_INPUT' && f.props.inputType === 'mp_id';
-          });
-        }
-      });
-      searchField = mpIdFilter ? mpIdFilter.id : 'task_ids';
-    }
     const submitValue = value || searchValue;
-    actions.setFilterWithOverrides(submitValue, searchField, getFieldsToOverride(searchInputType));
+    const searchField = props.allowedInputTypesMap[searchInputType].field;
+    const allowedFields = Object.keys(props.allowedInputTypesMap).map((d) => {
+      return props.allowedInputTypesMap[d].field;
+    });
+    const fieldsToOverride = allowedFields?.filter((d) => d !== searchField);
+    actions.setFilterWithOverrides(submitValue, searchField, fieldsToOverride);
   };
 
   /**
@@ -81,6 +69,8 @@ export const SearchUISearchBar: React.FC = () => {
       allowSmiles={allowSmiles}
       tooltip={state.searchBarTooltip}
       placeholder={state.searchBarPlaceholder}
+      allowedInputTypes={convertMaterialsInputTypesMapToArray(props.allowedInputTypesMap)}
+      errorMessage={props.errorMessage}
     />
   );
 };

--- a/src/components/search/SearchUI/utils.tsx
+++ b/src/components/search/SearchUI/utils.tsx
@@ -13,7 +13,7 @@ import { ActiveFilter, Column, ColumnFormat, FilterGroup, FilterType, SearchStat
 import { Link } from '../../navigation/Link';
 import { spaceGroups } from '../../../constants/spaceGroups';
 import { MaterialsInputType } from '../MaterialsInput';
-import { validateElements } from '../MaterialsInput/utils';
+import { MaterialsInputTypesMap, validateElements } from '../MaterialsInput/utils';
 import { useMediaQuery } from 'react-responsive';
 import { SearchUIProps } from '.';
 import { MaterialsInputBox } from '../MaterialsInput/MaterialsInputBox';
@@ -403,4 +403,16 @@ export const getDefaultFiltersAndValues = (state: SearchState) => {
     filterValues,
     activeFilters,
   };
+};
+
+export const convertMaterialsInputTypesMapToArray = (map?: MaterialsInputTypesMap) => {
+  if (map) {
+    let arr: MaterialsInputType[] = [];
+    for (const inputType in map) {
+      arr.push(inputType as MaterialsInputType);
+    }
+    return arr;
+  } else {
+    return;
+  }
 };

--- a/src/views/BatteryExplorer/filterGroups.json
+++ b/src/views/BatteryExplorer/filterGroups.json
@@ -29,7 +29,8 @@
         "id": "elements",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "elements"
+          "inputType": "elements",
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (for records with at least these elements) or a hyphen (for records with only these elements)."
         }
       },
       {
@@ -37,7 +38,8 @@
         "id": "exclude_elements",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "exclude_elements"
+          "inputType": "elements",
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (e.g. Ce, Zn)."
         }
       },
       {
@@ -45,7 +47,8 @@
         "id": "formula",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "formula"
+          "inputType": "formula",
+          "errorMessage": "Please enter a valid chemical formula (e.g. CeZn5)."
         }
       }
     ]

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -23,21 +23,23 @@ export const MaterialsExplorer: React.FC = () => {
             : undefined
         }
         apiKey={undefined}
-        searchBarTooltip="Type in a comma-separated list of element symbols (e.g. Ga, N), a chemical formula (e.g. C3N), or a material id (e.g. mp-10152). You can also click elements on the periodic table to add them to your search."
-        searchBarPlaceholder="Search by elements, formula, or mp-id"
         sortField="energy_above_hull"
         sortAscending={true}
         selectableRows={true}
-        // conditionalRowStyles={[
-        //   {
-        //     selector: 'is_stable',
-        //     value: true,
-        //     style: {
-        //       backgroundColor: '#DBE2FA',
-        //       boxShadow: '4px 0px 0px 0px #000 inset',
-        //     },
-        //   },
-        // ]}
+        searchBarTooltip="Type in a comma-separated list of element symbols (e.g. Ga, N), a chemical formula (e.g. C3N), or a material id (e.g. mp-10152). You can also click elements on the periodic table to add them to your search."
+        searchBarPlaceholder="Search by elements, formula, or mp-id"
+        searchBarErrorMessage="Please enter a valid formula (e.g. CeZn5), list of elements (e.g. Ce, Zn or Ce-Zn), or ID (e.g. mp-394 or mol-54330)."
+        searchBarAllowedInputTypesMap={{
+          formula: {
+            field: 'formula',
+          },
+          elements: {
+            field: 'elements',
+          },
+          mpid: {
+            field: 'material_ids',
+          },
+        }}
       />
     </>
   );

--- a/src/views/MaterialsExplorer/filterGroups.json
+++ b/src/views/MaterialsExplorer/filterGroups.json
@@ -8,7 +8,8 @@
         "id": "material_ids",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "mp_id",
+          "inputType": "mpid",
+          "errorMessage": "Please enter a valid material ID (e.g. mp-394).",
           "periodicTableMode": null
         }
       },
@@ -19,7 +20,7 @@
         "type": "MATERIALS_INPUT",
         "props": {
           "inputType": "elements",
-          "displayName": "include elements"
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (for records with at least these elements) or a hyphen (for records with only these elements)."
         }
       },
       {
@@ -27,7 +28,8 @@
         "id": "exclude_elements",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "exclude_elements"
+          "inputType": "elements",
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (e.g. Ce, Zn)."
         }
       },
       {
@@ -35,7 +37,8 @@
         "id": "formula",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "formula"
+          "inputType": "formula",
+          "errorMessage": "Please enter a valid chemical formula (e.g. CeZn5)."
         }
       }
     ]

--- a/src/views/MoleculesExplorer/filterGroups.json
+++ b/src/views/MoleculesExplorer/filterGroups.json
@@ -8,7 +8,8 @@
         "id": "task_ids",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "mp_id",
+          "inputType": "mpid",
+          "errorMessage": "Please enter a valid molecule ID (e.g. mol-25709).",
           "periodicTableMode": null
         }
       },
@@ -17,7 +18,8 @@
         "id": "elements",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "elements"
+          "inputType": "elements",
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (for records with at least these elements) or a hyphen (for records with only these elements)."
         }
       },
       {
@@ -34,13 +36,19 @@
         "id": "formula",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "formula"
+          "inputType": "formula",
+          "errorMessage": "Please enter a valid chemical formula (e.g. H8C5O3)."
         }
       },
       {
         "name": "SMILES",
         "id": "smiles",
-        "type": "TEXT_INPUT"
+        "type": "MATERIALS_INPUT",
+        "props": {
+          "inputType": "smiles",
+          "errorMessage": "Please enter a valid SMILES value.",
+          "periodicTableMode": null
+        }
       }
     ]
   },

--- a/src/views/XasApp/filterGroups.json
+++ b/src/views/XasApp/filterGroups.json
@@ -35,7 +35,8 @@
         "id": "absorbing_element",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "absorbing_element"
+          "inputType": "absorbing_element",
+          "errorMessage": "Please enter a valid element symbol"
         }
       },
       {
@@ -43,7 +44,8 @@
         "id": "elements",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "elements"
+          "inputType": "elements",
+          "errorMessage": "Please enter a valid list of element symbols separated by a comma (for records with at least these elements) or a hyphen (for records with only these elements)."
         }
       },
       {
@@ -51,7 +53,8 @@
         "id": "formula",
         "type": "MATERIALS_INPUT",
         "props": {
-          "inputType": "formula"
+          "inputType": "formula",
+          "errorMessage": "Please enter a valid chemical formula (e.g. CeZn5)."
         }
       }
     ]


### PR DESCRIPTION
- New `SearchUI` prop `searchBarAllowedInputTypesMap`
  - This prop gives you the ability to set which input types are allowed inside the top search bar AND map those input types to data fields
  - Prop value must be an object whose keys are the allowed input types. Possible key values are: "elements", "formula", "mpid", "smiles", and "text"
  - Each key object must have a `field` property which maps the input type to a valid data field
  - Note that an input type can only be used once so must map to only one data field
  - Example:
```
{
  formula: {
    field: 'target_formula'
  },
  elements: {
    field: 'elements'
  },
  mpid: {
    field: 'material_ids'
  }
}
```  

- New `SearchUI` prop `searchBarErrorMessage`
  - Custom error message to display with the top-level search bar if the user types an invalid value
- New `MaterialsInput` prop `errorMessage`
  - Custom error message to display if the user types an invalid value
  - In the `SearchUI` `filterGroups` json, this prop can be added to filters with `"type": "MATERIALS_INPUT"` as a property in their `props` object