### PR TITLE
Add props to SearchUI to support card view and custom card view

### DIFF
--- a/src/components/search/DataCard/DataCard.css
+++ b/src/components/search/DataCard/DataCard.css
@@ -1,0 +1,20 @@
+.mpc-data-card {
+  display: inline-flex;
+}
+
+.mpc-data-card-right {
+  flex: 1;
+  margin-left: 1rem;
+}
+
+.mpc-data-card-right-bottom > * {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  column-gap: 1rem;
+  row-gap: 1rem;
+}
+
+.mpc-data-card-right-bottom p:first-child {
+  font-weight: 600;
+}

--- a/src/components/search/DataCard/DataCard.tsx
+++ b/src/components/search/DataCard/DataCard.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+
+interface KeyLabelPair {
+  key: string;
+  label: string;
+}
+
+interface Props {
+  id?: string;
+  setProps?: (value: any) => any;
+  className?: string;
+  data: object;
+  levelOneKey?: string;
+  levelTwoKey?: string;
+  levelThreeKeys?: KeyLabelPair[];
+  leftComponent?: ReactNode;
+}
+
+export const DataCard: React.FC<Props> = (props) => {
+  return (
+    <div className={classNames('mpc-data-card', props.className)}>
+      <div>{props.leftComponent}</div>
+      <div>
+        {props.levelOneKey && <p>{props.data[props.levelOneKey]}</p>}
+        {props.levelTwoKey && <p>{props.data[props.levelTwoKey]}</p>}
+        <div>
+          {props.levelThreeKeys?.map((d, i) => (
+            <div key={`mpc-data-card-three-${i}`}>
+              <p>{d.label}</p>
+              <p>{props.data[d.key] || '-'}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/search/DataCard/DataCard.tsx
+++ b/src/components/search/DataCard/DataCard.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
+import './DataCard.css';
 
 interface KeyLabelPair {
   key: string;
@@ -20,17 +21,39 @@ interface Props {
 export const DataCard: React.FC<Props> = (props) => {
   return (
     <div className={classNames('mpc-data-card', props.className)}>
-      <div>{props.leftComponent}</div>
-      <div>
-        {props.levelOneKey && <p>{props.data[props.levelOneKey]}</p>}
-        {props.levelTwoKey && <p>{props.data[props.levelTwoKey]}</p>}
-        <div>
-          {props.levelThreeKeys?.map((d, i) => (
-            <div key={`mpc-data-card-three-${i}`}>
-              <p>{d.label}</p>
-              <p>{props.data[d.key] || '-'}</p>
-            </div>
-          ))}
+      <div className="mpc-data-card-left">{props.leftComponent}</div>
+      <div className="mpc-data-card-right">
+        {props.levelOneKey && <p className="title is-4">{props.data[props.levelOneKey]}</p>}
+        {props.levelTwoKey && <p className="subtitle">{props.data[props.levelTwoKey]}</p>}
+        <div className="mpc-data-card-right-bottom">
+          <div>
+            {props.levelThreeKeys && props.levelThreeKeys[0] && (
+              <div>
+                <p>{props.levelThreeKeys[0].label}</p>
+                <p>{props.data[props.levelThreeKeys[0].key] || '-'}</p>
+              </div>
+            )}
+            {props.levelThreeKeys && props.levelThreeKeys[1] && (
+              <div>
+                <p>{props.levelThreeKeys[1].label}</p>
+                <p>{props.data[props.levelThreeKeys[1].key] || '-'}</p>
+              </div>
+            )}
+          </div>
+          <div>
+            {props.levelThreeKeys && props.levelThreeKeys[2] && (
+              <div>
+                <p>{props.levelThreeKeys[2].label}</p>
+                <p>{props.data[props.levelThreeKeys[2].key] || '-'}</p>
+              </div>
+            )}
+            {props.levelThreeKeys && props.levelThreeKeys[3] && (
+              <div>
+                <p>{props.levelThreeKeys[3].label}</p>
+                <p>{props.data[props.levelThreeKeys[3].key] || '-'}</p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/search/DataCard/index.tsx
+++ b/src/components/search/DataCard/index.tsx
@@ -1,0 +1,1 @@
+export { DataCard } from './DataCard';

--- a/src/components/search/Paginator/Paginator.tsx
+++ b/src/components/search/Paginator/Paginator.tsx
@@ -9,7 +9,7 @@ interface Props {
   rowsPerPage: number;
   rowCount: number;
   onChangePage: (page: number) => any;
-  onChangeRowsPerPage: (rowsPerPage: number) => any;
+  onChangeRowsPerPage?: (rowsPerPage: number) => any;
   currentPage: number;
 }
 

--- a/src/components/search/SearchUI/SearchUI.css
+++ b/src/components/search/SearchUI/SearchUI.css
@@ -94,13 +94,13 @@
   font-weight: normal;
 }
 
-.mpc-search-ui .mpc-table-header {
+.mpc-search-ui .mpc-search-ui-data-header-content {
   display: flex;
   justify-content: space-between;
   flex-flow: wrap;
 }
 
-.mpc-search-ui .mpc-table-header .subtitle {
+.mpc-search-ui .mpc-search-ui-data-header-content .subtitle {
   height: 0;
 }
 
@@ -149,21 +149,30 @@
   line-height: 1;
 }
 
-.mpc-search-ui-data-table-controls > * {
+.mpc-search-ui .mpc-search-ui-data-header-controls > * {
   text-align: left;
+  margin-bottom: 0;
 }
 
-.mpc-search-ui-data-table-controls > *:not(:last-child) {
+.mpc-search-ui-data-header-controls > *:not(:last-child) {
   margin-right: 0.25rem;
+}
+
+.mpc-search-ui-data-header-controls .field.has-addons {
+  display: inline-flex;
 }
 
 .mpc-search-ui .mpc-paginator,
 .mpc-search-ui .mpc-active-filter-buttons,
-.mpc-search-ui .react-data-table {
+.mpc-search-ui .mpc-search-ui-data-view {
   margin-top: 0.5rem;
 }
 
-.mpc-search-ui .pagination {
+.mpc-search-ui .pagination:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.mpc-search-ui .pagination:last-child {
   margin-bottom: 0;
 }
 
@@ -173,4 +182,17 @@
 .mpc-search-ui .pagination-previous {
   margin-top: 0;
   margin-bottom: 0;
+}
+
+.mpc-search-ui .button.is-active {
+  background: #3960e3;
+  color: #fff;
+  border-color: #dbdbdb;
+}
+
+.mpc-search-ui .mpc-search-ui-data-cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  column-gap: 2em;
+  row-gap: 2em;
 }

--- a/src/components/search/SearchUI/SearchUI.css
+++ b/src/components/search/SearchUI/SearchUI.css
@@ -196,3 +196,7 @@
   column-gap: 2em;
   row-gap: 2em;
 }
+
+.mpc-search-ui .mpc-search-ui-data-cards-container .box {
+  margin-bottom: 0;
+}

--- a/src/components/search/SearchUI/SearchUI.test.tsx
+++ b/src/components/search/SearchUI/SearchUI.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen, cleanup } from '@testing-library/react';
 import { SearchUI, SearchUIProps } from '.';
-import { FilterGroup } from './types';
+import { FilterGroup, SearchUIView } from './types';
 import filterGroups from '../../../views/MaterialsExplorer/filterGroups.json';
 import columns from '../../../views/MaterialsExplorer/columns.json';
 import { materialsByIdQuery } from '../../../mocks/constants/materialsById';
@@ -15,6 +15,7 @@ jest.mock('../MaterialsInput/MaterialsInput.css', () => {});
 jest.mock('../DualRangeSlider/DualRangeSlider.css', () => {});
 jest.mock('../Select/Select.css', () => {});
 jest.mock('../ActiveFilterButtons/ActiveFilterButtons.css', () => {});
+jest.mock('../DataCard/DataCard.css', () => {});
 jest.mock('../../periodic-table/periodic-table-component/periodic-table.module.less', () => {});
 jest.mock('../../periodic-table/periodic-element/periodic-element.module.less', () => {});
 jest.mock('../../periodic-table/periodic-element/periodic-element.detailed.less', () => {});
@@ -67,10 +68,9 @@ describe('<SearchUI/>', () => {
     expect(screen.getByTestId('data-table-title')).toBeInTheDocument();
     expect(screen.getByTestId('columns-menu')).toBeInTheDocument();
     expect(screen.getByTestId('results-per-page-menu')).toBeInTheDocument();
-    expect(screen.getByTestId('react-data-table-container')).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByTestId('active-filter-buttons').childNodes.length).toBe(0);
       expect(screen.getAllByRole('row').length).toBe(16);
+      expect(screen.getByTestId('react-data-table-container')).toBeInTheDocument();
     });
   });
 

--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -11,11 +11,7 @@ import { MaterialsInputTypesMap } from '../MaterialsInput/utils';
 import { SearchUIDataHeader } from './SearchUIDataHeader';
 import { SearchUIDataCards } from './SearchUIDataCards';
 import { SearchUIDataView } from './SearchUIDataView';
-
-/**
- * Component for rendering advanced search interfaces for data in an API
- * Renders results in a data table alongside a set of filters that map to properties in the data.
- */
+import { CustomCardType } from './utils';
 
 export interface SearchUIProps {
   /**
@@ -202,47 +198,64 @@ export interface SearchUIProps {
    */
   conditionalRowStyles?: ConditionalRowStyle[];
 
+  /**
+   * Optionally include/exclude checkboxes next to rows for selecting
+   */
   selectableRows?: boolean;
 
+  /**
+   * Property to maintain the state of selected rows so that
+   * they are accessible via Dash callback
+   */
   selectedRows?: any[];
 
+  /**
+   * Set the initial results view to one of the preset
+   * SearchUI views: 'table' or 'cards'
+   */
   view?: SearchUIView;
 
+  /**
+   * Optionally enable/disable switching between SearchUI result views
+   */
   allowViewSwitching?: boolean;
 
-  customCardType?: string;
+  /**
+   * Change type of card displayed in the card results view
+   * Must be one of the values in the CustomCardType enum
+   *
+   * To add a custom card type, head to SearchUI/utils and add the name of the type to the
+   * CustomCardType enum, then add a property in customCardsMap using the same name
+   * you used for the type, then provide your custom component as the value.
+   *
+   * Note that custom card components must have these 3 (and only these 3) props: "data", "id", "className"
+   * The "data" prop will be the individual row of data in the results for populating the card's content.
+   */
+  customCardType?: CustomCardType;
 
+  /**
+   * Set of options for configuring what is displayed in the result cards
+   * when in the cards view.
+   * Must be an object with the following properties:
+    {
+      imageBaseURL: '', // Base of the URL to use to get images for the left side of the card
+      imageKey: 'material_id', // Data key to use to append value to the base URL (i.e. the name of the image file). The .png extension is added automatically.
+      levelOneKey: 'material_id', // Data key to use for the first line of text on the card
+      levelTwoKey: 'formula_pretty', // Data key to use for the second line of text on the card
+      levelThreeKeys: [ // List of data keys and labels to display under the first and second line of text
+        { key: 'energy_above_hull', label: 'Energy Above Hull' },
+        { key: 'formation_energy_per_atom', label: 'Formation Energy' },
+      ],
+    }
+   */
   cardOptions?: any;
 }
 
-export const SearchUI: React.FC<SearchUIProps> = ({
-  view = SearchUIView.TABLE,
-  resultLabel = 'results',
-  hasSearchBar = true,
-  conditionalRowStyles = [],
-  searchBarAllowedInputTypesMap = {
-    formula: {
-      field: 'formula',
-    },
-    elements: {
-      field: 'elements',
-    },
-    mpid: {
-      field: 'material_ids',
-    },
-  },
-  setProps = () => null,
-  ...otherProps
-}) => {
-  let props = {
-    view,
-    resultLabel,
-    hasSearchBar,
-    conditionalRowStyles,
-    searchBarAllowedInputTypesMap,
-    setProps,
-    ...otherProps,
-  };
+/**
+ * Component for rendering advanced search interfaces for data in an API
+ * Renders results alongside a set of filters that map to properties in the data.
+ */
+export const SearchUI: React.FC<SearchUIProps> = (props) => {
   return (
     <div id={props.id} className="mpc-search-ui">
       <Router>
@@ -253,7 +266,7 @@ export const SearchUI: React.FC<SearchUIProps> = ({
                 <div className="columns mb-1">
                   <div className="column pb-2">
                     <SearchUISearchBar
-                      allowedInputTypesMap={props.searchBarAllowedInputTypesMap}
+                      allowedInputTypesMap={props.searchBarAllowedInputTypesMap!}
                       errorMessage={props.searchBarErrorMessage}
                     />
                   </div>
@@ -274,4 +287,23 @@ export const SearchUI: React.FC<SearchUIProps> = ({
       </Router>
     </div>
   );
+};
+
+SearchUI.defaultProps = {
+  view: SearchUIView.TABLE,
+  resultLabel: 'results',
+  hasSearchBar: true,
+  conditionalRowStyles: [],
+  searchBarAllowedInputTypesMap: {
+    formula: {
+      field: 'formula',
+    },
+    elements: {
+      field: 'elements',
+    },
+    mpid: {
+      field: 'material_ids',
+    },
+  },
+  setProps: () => null,
 };

--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { SearchUIContextProvider } from './SearchUIContextProvider';
 import { SearchUIFilters } from './SearchUIFilters';
 import { SearchUIDataTable } from './SearchUIDataTable';
-import { Column, FilterGroup, ConditionalRowStyle } from './types';
+import { Column, FilterGroup, ConditionalRowStyle, SearchUIView } from './types';
 import { SearchUISearchBar } from './SearchUISearchBar';
 import './SearchUI.css';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -10,6 +10,7 @@ import { MaterialsInputType } from '../MaterialsInput';
 import { MaterialsInputTypesMap } from '../MaterialsInput/utils';
 import { SearchUIDataHeader } from './SearchUIDataHeader';
 import { SearchUIDataCards } from './SearchUIDataCards';
+import { SearchUIDataView } from './SearchUIDataView';
 
 /**
  * Component for rendering advanced search interfaces for data in an API
@@ -205,15 +206,17 @@ export interface SearchUIProps {
 
   selectedRows?: any[];
 
-  view?: 'table' | 'cards';
+  view?: SearchUIView;
 
   allowViewSwitching?: boolean;
 
   customCardType?: string;
+
+  cardOptions?: any;
 }
 
 export const SearchUI: React.FC<SearchUIProps> = ({
-  view = 'table',
+  view = SearchUIView.TABLE,
   resultLabel = 'results',
   hasSearchBar = true,
   conditionalRowStyles = [],
@@ -264,11 +267,7 @@ export const SearchUI: React.FC<SearchUIProps> = ({
             </div>
             <div className="column is-8-desktop is-half-tablet mpc-results-container">
               <SearchUIDataHeader />
-              {props.view === 'table' ? (
-                <SearchUIDataTable />
-              ) : props.view === 'cards' ? (
-                <SearchUIDataCards />
-              ) : null}
+              <SearchUIDataView />
             </div>
           </div>
         </SearchUIContextProvider>

--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -8,6 +8,8 @@ import './SearchUI.css';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { MaterialsInputType } from '../MaterialsInput';
 import { MaterialsInputTypesMap } from '../MaterialsInput/utils';
+import { SearchUIDataHeader } from './SearchUIDataHeader';
+import { SearchUIDataCards } from './SearchUIDataCards';
 
 /**
  * Component for rendering advanced search interfaces for data in an API
@@ -202,9 +204,16 @@ export interface SearchUIProps {
   selectableRows?: boolean;
 
   selectedRows?: any[];
+
+  view?: 'table' | 'cards';
+
+  allowViewSwitching?: boolean;
+
+  customCardType?: string;
 }
 
 export const SearchUI: React.FC<SearchUIProps> = ({
+  view = 'table',
   resultLabel = 'results',
   hasSearchBar = true,
   conditionalRowStyles = [],
@@ -223,6 +232,7 @@ export const SearchUI: React.FC<SearchUIProps> = ({
   ...otherProps
 }) => {
   let props = {
+    view,
     resultLabel,
     hasSearchBar,
     conditionalRowStyles,
@@ -253,7 +263,12 @@ export const SearchUI: React.FC<SearchUIProps> = ({
               </div>
             </div>
             <div className="column is-8-desktop is-half-tablet mpc-results-container">
-              <SearchUIDataTable />
+              <SearchUIDataHeader />
+              {props.view === 'table' ? (
+                <SearchUIDataTable />
+              ) : props.view === 'cards' ? (
+                <SearchUIDataCards />
+              ) : null}
             </div>
           </div>
         </SearchUIContextProvider>

--- a/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import qs from 'qs';
 import { usePrevious, useQuery } from '../../../../utils/hooks';
-import { SearchState } from '../types';
+import { Column, SearchState } from '../types';
 import { SearchUIProps } from '../../SearchUI';
 import { useHistory } from 'react-router-dom';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -57,11 +57,11 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
   const prevActiveFilters = usePrevious(state.activeFilters);
 
   const actions = {
-    setPage: (value: number) => {
-      setState((currentState) => ({ ...currentState, page: value }));
+    setPage: (page: number) => {
+      setState((currentState) => ({ ...currentState, page }));
     },
-    setResultsPerPage: (value: number) => {
-      setState((currentState) => ({ ...currentState, resultsPerPage: value }));
+    setResultsPerPage: (resultsPerPage: number) => {
+      setState((currentState) => ({ ...currentState, resultsPerPage }));
     },
     setSort: (field: string, ascending: boolean) => {
       setState((currentState) => ({
@@ -70,6 +70,9 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
         sortAscending: ascending,
         page: 1,
       }));
+    },
+    setColumns: (columns: Column[]) => {
+      setState((currentState) => ({ ...currentState, columns }));
     },
     setFilterValue: (value: any, id: string) => {
       setState((currentState) =>

--- a/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -123,10 +123,7 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
     },
     getData: () => {
       setState((currentState) => {
-        /**
-         * Only show the loading icon if this is a filter change
-         * not on simple page change
-         */
+        /** Only show the loading icon if this is a filter change not on simple page change */
         const showLoading = currentState.activeFilters !== prevActiveFilters ? true : false;
         let isLoading = showLoading;
         let minLoadTime = 1000;

--- a/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import qs from 'qs';
 import { usePrevious, useQuery } from '../../../../utils/hooks';
-import { Column, SearchState } from '../types';
+import { Column, SearchState, SearchUIView } from '../types';
 import { SearchUIProps } from '../../SearchUI';
 import { useHistory } from 'react-router-dom';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -63,13 +63,30 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
     setResultsPerPage: (resultsPerPage: number) => {
       setState((currentState) => ({ ...currentState, resultsPerPage }));
     },
-    setSort: (field: string, ascending: boolean) => {
+    setSort: (sortField: string, sortAscending: boolean) => {
       setState((currentState) => ({
         ...currentState,
-        sortField: field,
-        sortAscending: ascending,
+        sortField,
+        sortAscending,
         page: 1,
       }));
+    },
+    setSortField: (sortField: string) => {
+      setState((currentState) => ({
+        ...currentState,
+        sortField,
+        page: 1,
+      }));
+    },
+    setSortAscending: (sortAscending: boolean) => {
+      setState((currentState) => ({
+        ...currentState,
+        sortAscending,
+        page: 1,
+      }));
+    },
+    setView: (view: SearchUIView) => {
+      setState((currentState) => ({ ...currentState, view }));
     },
     setColumns: (columns: Column[]) => {
       setState((currentState) => ({ ...currentState, columns }));

--- a/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/search/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -176,7 +176,7 @@ export const SearchUIContextProvider: React.FC<SearchUIProps> = ({
             query.set(field, s.value);
           });
         });
-        console.log(params);
+
         axios
           .get(props.baseURL, {
             params: params,

--- a/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
+++ b/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
@@ -5,15 +5,13 @@ import { DataCard } from '../../DataCard';
 import { getCustomCardComponent } from '../utils';
 
 /**
- * Component for rendering data returned within a SearchUI component
- * Table data and interactions are hooked up to the SearchUIContext state and actions
+ * Component for rendering SearchUI results in the cards view
+ * Will use the DataCard component to render results as a grid
+ * of cards where each shows an image and a few select data properties.
+ * If a customCardType is supplied to the SearchUI, this component
+ * will use the customCardMap to find a different component to render the cards.
  */
-
-interface Props {
-  className?: string;
-}
-
-export const SearchUIDataCards: React.FC<Props> = (props) => {
+export const SearchUIDataCards: React.FC = () => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
   const tableRef = useRef<HTMLDivElement>(null);

--- a/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
+++ b/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
@@ -1,36 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
-import DataTable from 'react-data-table-component';
-import { ActiveFilterButtons } from '../../../search/ActiveFilterButtons';
-import NumberFormat from 'react-number-format';
-import { FaAngleDown, FaCaretDown, FaExclamationTriangle, FaLink } from 'react-icons/fa';
-import { Wrapper as MenuWrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
 import { Paginator } from '../../Paginator';
-import classNames from 'classnames';
-import { pluralize } from '../../utils';
-import { v4 as uuidv4 } from 'uuid';
-import * as d3 from 'd3';
-import { ConditionalRowStyle } from '../types';
-import { DownloadDropdown } from '../../DownloadDropdown';
 import { DataCard } from '../../DataCard';
-import { BibCard } from '../../BibCard';
+import { getCustomCardComponent } from '../utils';
 
 /**
  * Component for rendering data returned within a SearchUI component
  * Table data and interactions are hooked up to the SearchUIContext state and actions
  */
-
-const customCardsMap = {
-  synthesis: BibCard,
-};
-
-const getCustomCardComponent = (cardType?: string) => {
-  if (cardType && customCardsMap.hasOwnProperty(cardType)) {
-    return customCardsMap[cardType];
-  } else {
-    return null;
-  }
-};
 
 interface Props {
   className?: string;
@@ -49,82 +26,52 @@ export const SearchUIDataCards: React.FC<Props> = (props) => {
     actions.setPage(page);
   };
 
-  const handlePerRowsChange = (perPage: number) => {
-    actions.setResultsPerPage(perPage);
-  };
-
-  const handleSort = (column, sortDirection) => {
-    const sortAscending = sortDirection === 'asc' ? true : false;
-    actions.setSort(column.selector, sortAscending);
-  };
-
   const CustomPaginator = () => (
     <Paginator
       rowCount={state.totalResults}
       rowsPerPage={state.resultsPerPage}
       currentPage={state.page}
       onChangePage={handlePageChange}
-      onChangeRowsPerPage={handlePerRowsChange}
     />
   );
 
-  const NoDataMessage = () => {
-    if (state.error) {
-      return (
-        <div className="react-data-table-message">
-          <p>
-            <FaExclamationTriangle /> There was an error with your search.
-          </p>
-          <p>
-            You may have entered an invalid search value. Otherwise, the API may be temporarily
-            unavailable.
-          </p>
-        </div>
-      );
-    } else {
-      return (
-        <div className="react-data-table-message">
-          <p>No records match your search criteria</p>
-        </div>
-      );
-    }
-  };
-
   return (
-    <div className="mpc-search-ui-data-table">
-      {state.resultsPerPage > 15 && <CustomPaginator />}
-      <div className="columns react-data-table-outer-container">
-        <div
-          data-testid="react-data-table-container"
-          className="column react-data-table-container"
-          ref={tableRef}
-        >
-          {state.results.map((d, i) => {
-            if (CustomCardComponent) {
-              return (
-                <CustomCardComponent
-                  key={`mpc-data-card-${i}`}
-                  className="mpc-search-ui-custom-card"
-                  data={d}
-                />
-              );
-            } else {
-              return (
-                <DataCard
-                  key={`mpc-data-card-${i}`}
-                  className="box mpc-search-ui-data-card"
-                  data={d}
-                  levelOneKey="material_id"
-                  levelTwoKey="formula_pretty"
-                  levelThreeKeys={[
-                    { key: 'energy_above_hull', label: 'Energy Above Hull' },
-                    { key: 'nsites', label: 'n sites' },
-                  ]}
-                />
-              );
-            }
-          })}
-        </div>
+    <div className="mpc-search-ui-data-cards">
+      <CustomPaginator />
+      <div
+        data-testid="mpc-search-ui-data-cards-container"
+        className="mpc-search-ui-data-cards-container"
+        ref={tableRef}
+      >
+        {state.results.map((d, i) => {
+          if (CustomCardComponent) {
+            return (
+              <CustomCardComponent
+                key={`mpc-data-card-${i}`}
+                className="mpc-search-ui-custom-card"
+                data={d}
+              />
+            );
+          } else {
+            return (
+              <DataCard
+                key={`mpc-data-card-${i}`}
+                className="box mpc-search-ui-data-card"
+                data={d}
+                levelOneKey={state.cardOptions.levelOneKey}
+                levelTwoKey={state.cardOptions.levelTwoKey}
+                levelThreeKeys={state.cardOptions.levelThreeKeys}
+                leftComponent={
+                  <figure className="image is-128x128">
+                    <img
+                      src={state.cardOptions.imageBaseURL + d[state.cardOptions.imageKey] + '.png'}
+                    />
+                  </figure>
+                }
+              />
+            );
+          }
+        })}
       </div>
       <CustomPaginator />
     </div>

--- a/src/components/search/SearchUI/SearchUIDataCards/index.tsx
+++ b/src/components/search/SearchUI/SearchUIDataCards/index.tsx
@@ -1,0 +1,1 @@
+export { SearchUIDataCards } from './SearchUIDataCards';

--- a/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
@@ -11,16 +11,6 @@ import * as d3 from 'd3';
 import { SortDropdown } from '../../SortDropdown';
 import { DropdownItem } from '../../SortDropdown/SortDropdown';
 
-/**
- * Render information about SearchUI results as well as controls
- * for modifying the data in the results view.
- * Information and interactions are hooked up to the SearchUIContext state and actions.
- */
-
-interface Props {
-  className?: string;
-}
-
 const componentHtmlId = uuidv4();
 
 const getLowerResultBound = (totalResults: number, resultsPerPage: number, page: number) => {
@@ -45,7 +35,11 @@ const getUpperResultBound = (
   }
 };
 
-export const SearchUIDataHeader: React.FC<Props> = (props) => {
+/**
+ * Render information about SearchUI results as well as controls
+ * for modifying the data in the results view.
+ */
+export const SearchUIDataHeader: React.FC = () => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
   const [titleHover, setTitleHover] = useState(false);

--- a/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
@@ -14,8 +14,9 @@ import { ConditionalRowStyle } from '../types';
 import { DownloadDropdown } from '../../DownloadDropdown';
 
 /**
- * Component for rendering data returned within a SearchUI component
- * Table data and interactions are hooked up to the SearchUIContext state and actions
+ * Render information about SearchUI results as well as controls
+ * for modifying the data in the results view.
+ * Information and interactions are hooked up to the SearchUIContext state and actions.
  */
 
 interface Props {
@@ -46,7 +47,7 @@ const getUpperResultBound = (
   }
 };
 
-export const SearchUIDataTable: React.FC<Props> = (props) => {
+export const SearchUIDataHeader: React.FC<Props> = (props) => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
   const [titleHover, setTitleHover] = useState(false);
@@ -67,31 +68,6 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
     state.resultsPerPage,
     lowerResultBound
   );
-
-  const handlePageChange = (page: number) => {
-    /** Scroll table back to top when page changes */
-    if (tableRef.current) {
-      tableRef.current.children[0].scrollTop = 0;
-    }
-    actions.setPage(page);
-    setToggleClearRows(!toggleClearRows);
-  };
-
-  const handlePerRowsChange = (perPage: number) => {
-    actions.setResultsPerPage(perPage);
-    setToggleClearRows(!toggleClearRows);
-  };
-
-  const handleSort = (column, sortDirection) => {
-    const sortAscending = sortDirection === 'asc' ? true : false;
-    actions.setSort(column.selector, sortAscending);
-    setToggleClearRows(!toggleClearRows);
-  };
-
-  const handleSelectedRowsChange = (rowState) => {
-    console.log(rowState);
-    actions.setSelectedRows(rowState.selectedRows);
-  };
 
   const toggleColumn = (columnIndex: number) => {
     const newColumns = [...columns];
@@ -320,43 +296,6 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
     </MenuWrapper>
   );
 
-  const CustomPaginator = () => (
-    <Paginator
-      rowCount={state.totalResults}
-      rowsPerPage={state.resultsPerPage}
-      currentPage={state.page}
-      onChangePage={handlePageChange}
-      onChangeRowsPerPage={handlePerRowsChange}
-    />
-  );
-
-  const NoDataMessage = () => {
-    if (state.error) {
-      return (
-        <div className="react-data-table-message">
-          <p>
-            <FaExclamationTriangle /> There was an error with your search.
-          </p>
-          <p>
-            You may have entered an invalid search value. Otherwise, the API may be temporarily
-            unavailable.
-          </p>
-        </div>
-      );
-    } else {
-      return (
-        <div className="react-data-table-message">
-          <p>No records match your search criteria</p>
-        </div>
-      );
-    }
-  };
-
-  const conditionalRowStyles: any[] = state.conditionalRowStyles!.map((c) => {
-    c.when = (row) => row[c.selector] === c.value;
-    return c;
-  });
-
   return (
     <div id={componentHtmlId} className="mpc-search-ui-data-table">
       <div className="mpc-table-header">
@@ -380,49 +319,6 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
         filters={state.activeFilters}
         onClick={(v, id) => actions.setFilterValue(v, id)}
       />
-      {state.resultsPerPage > 15 && <CustomPaginator />}
-      <div className="columns react-data-table-outer-container">
-        <div
-          data-testid="react-data-table-container"
-          className="column react-data-table-container"
-          ref={tableRef}
-        >
-          <DataTable
-            className="react-data-table"
-            noHeader
-            theme="material"
-            columns={columns}
-            data={state.results}
-            highlightOnHover
-            pagination
-            paginationServer
-            paginationComponent={CustomPaginator}
-            sortServer
-            sortIcon={<FaCaretDown />}
-            defaultSortField={state.sortField}
-            defaultSortAsc={state.sortAscending}
-            onSort={handleSort}
-            customStyles={{
-              rows: {
-                style: {
-                  minHeight: '3em',
-                },
-              },
-            }}
-            conditionalRowStyles={conditionalRowStyles}
-            noDataComponent={<NoDataMessage />}
-            selectableRows={state.selectableRows}
-            onSelectedRowsChange={handleSelectedRowsChange}
-            clearSelectedRows={toggleClearRows}
-            // selectableRowSelected={(row) => {
-            //   const isSelected = state.selectedRows?.find(s => s.material_id === row.material_id);
-            //   console.log(state.selectedRows);
-            //   console.log(row);
-            //   return isSelected;
-            // }}
-          />
-        </div>
-      </div>
     </div>
   );
 };

--- a/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
@@ -1,17 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
-import DataTable from 'react-data-table-component';
 import { ActiveFilterButtons } from '../../../search/ActiveFilterButtons';
 import NumberFormat from 'react-number-format';
-import { FaAngleDown, FaCaretDown, FaExclamationTriangle, FaLink } from 'react-icons/fa';
+import { FaAngleDown, FaLink } from 'react-icons/fa';
 import { Wrapper as MenuWrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
-import { Paginator } from '../../Paginator';
 import classNames from 'classnames';
 import { pluralize } from '../../utils';
 import { v4 as uuidv4 } from 'uuid';
 import * as d3 from 'd3';
-import { ConditionalRowStyle } from '../types';
-import { DownloadDropdown } from '../../DownloadDropdown';
 
 /**
  * Render information about SearchUI results as well as controls
@@ -51,9 +47,7 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
   const [titleHover, setTitleHover] = useState(false);
-  const [toggleClearRows, setToggleClearRows] = useState(false);
   const [columns, setColumns] = useState(state.columns.filter((c) => !c.hidden));
-  const tableRef = useRef<HTMLDivElement>(null);
   const [allCollumnsSelected, setAllCollumnsSelected] = useState(() => {
     const anyNotSelected = columns.find((col) => col.omit);
     return !anyNotSelected;
@@ -75,7 +69,7 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
     if (changedColumn) changedColumn.omit = !changedColumn.omit;
     const anyNotSelected = newColumns.find((col) => col.omit);
     setAllCollumnsSelected(!anyNotSelected);
-    setColumns(newColumns);
+    actions.setColumns(newColumns);
   };
 
   const toggleAllColumns = () => {
@@ -85,42 +79,12 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
       return col;
     });
     setAllCollumnsSelected(newAllColumnsSelected);
-    setColumns(newColumns);
+    actions.setColumns(newColumns);
   };
 
-  // const getDataToDownload = () => {
-  //   if (state.selectedRows && state.selectedRows.length > 0) {
-  //     return state.selectedRows;
-  //   } else {
-  //     return state.results;
-  //   }
-  // };
-
-  // const getDownloadFilename = () => {
-  //   if (state.selectedRows && state.selectedRows.length > 0) {
-  //     return `selected-results-${state.selectedRows.length}`;
-  //   } else {
-  //     return `results-${lowerResultBound}-${upperResultBound}`;
-  //   }
-  // };
-
-  // const getDownloadTooltip = () => {
-  //   if (state.selectedRows && state.selectedRows.length > 0) {
-  //     return `Includes ${state.selectedRows.length} selected rows`;
-  //   } else if (state.totalResults > state.resultsPerPage) {
-  //     return 'Includes current page only';
-  //   } else {
-  //     return;
-  //   }
-  // };
-
-  // const getDownloadLabel = () => {
-  //   if (state.selectedRows && state.selectedRows.length > 0) {
-  //     return 'Download selected as';
-  //   } else {
-  //     return 'Download as';
-  //   }
-  // };
+  const handlePerRowsChange = (perPage: number) => {
+    actions.setResultsPerPage(perPage);
+  };
 
   const TableHeaderTitle = () => {
     if (state.activeFilters.length === 0 && state.totalResults > 0 && !state.loading) {
@@ -185,16 +149,6 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
       );
     }
   };
-
-  // const downloadDropdown = (
-  //   <DownloadDropdown
-  //     data={getDataToDownload()}
-  //     filename={getDownloadFilename()}
-  //     tooltip={getDownloadTooltip()}
-  //   >
-  //     {getDownloadLabel()}
-  //   </DownloadDropdown>
-  // );
 
   const columnsMenu = (
     <MenuWrapper
@@ -297,7 +251,7 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
   );
 
   return (
-    <div id={componentHtmlId} className="mpc-search-ui-data-table">
+    <div id={componentHtmlId} className="mpc-search-ui-data-header">
       <div className="mpc-table-header">
         <div>
           <TableHeaderTitle />

--- a/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
 import { ActiveFilterButtons } from '../../../search/ActiveFilterButtons';
 import NumberFormat from 'react-number-format';
-import { FaAngleDown, FaLink } from 'react-icons/fa';
+import { FaAngleDown, FaLink, FaTable, FaThLarge } from 'react-icons/fa';
 import { Wrapper as MenuWrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
 import classNames from 'classnames';
 import { pluralize } from '../../utils';
 import { v4 as uuidv4 } from 'uuid';
 import * as d3 from 'd3';
+import { SortDropdown } from '../../SortDropdown';
+import { DropdownItem } from '../../SortDropdown/SortDropdown';
 
 /**
  * Render information about SearchUI results as well as controls
@@ -250,9 +252,50 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
     </MenuWrapper>
   );
 
+  const sortMenu = (
+    <SortDropdown
+      sortValues={state.results}
+      sortOptions={state.columns
+        .filter((c) => !c.hidden)
+        .map((c) => {
+          return { label: c.nameString, value: c.selector } as DropdownItem;
+        })}
+      sortField={state.sortField}
+      setSortField={actions.setSortField}
+      sortAscending={state.sortAscending}
+      setSortAscending={actions.setSortAscending}
+      sortFn={actions.setSort}
+    />
+  );
+
+  const viewSwitcher = (
+    <div className="field has-addons">
+      <div className="control">
+        <button
+          onClick={() => actions.setView('table')}
+          className={classNames('button', {
+            'is-active': state.view === 'table',
+          })}
+        >
+          <FaTable />
+        </button>
+      </div>
+      <div className="control">
+        <button
+          onClick={() => actions.setView('cards')}
+          className={classNames('button', {
+            'is-active': state.view === 'cards',
+          })}
+        >
+          <FaThLarge />
+        </button>
+      </div>
+    </div>
+  );
+
   return (
     <div id={componentHtmlId} className="mpc-search-ui-data-header">
-      <div className="mpc-table-header">
+      <div className="mpc-search-ui-data-header-content">
         <div>
           <TableHeaderTitle />
           <p className="subtitle is-7">
@@ -264,15 +307,19 @@ export const SearchUIDataHeader: React.FC<Props> = (props) => {
             <progress className="progress is-small is-primary" max="100"></progress>
           )}
         </div>
-        <div className="mpc-search-ui-data-table-controls">
-          {resultsPerPageMenu}
+        <div className="mpc-search-ui-data-header-controls">
+          {state.allowViewSwitching && viewSwitcher}
+          {sortMenu}
           {columnsMenu}
+          {resultsPerPageMenu}
         </div>
       </div>
-      <ActiveFilterButtons
-        filters={state.activeFilters}
-        onClick={(v, id) => actions.setFilterValue(v, id)}
-      />
+      {state.activeFilters.length > 0 && (
+        <ActiveFilterButtons
+          filters={state.activeFilters}
+          onClick={(v, id) => actions.setFilterValue(v, id)}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/search/SearchUI/SearchUIDataHeader/index.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/index.tsx
@@ -1,0 +1,1 @@
+export { SearchUIDataHeader } from './SearchUIDataHeader';

--- a/src/components/search/SearchUI/SearchUIDataTable/SearchUIDataTable.tsx
+++ b/src/components/search/SearchUI/SearchUIDataTable/SearchUIDataTable.tsx
@@ -1,17 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
 import DataTable from 'react-data-table-component';
-import { ActiveFilterButtons } from '../../../search/ActiveFilterButtons';
-import NumberFormat from 'react-number-format';
-import { FaAngleDown, FaCaretDown, FaExclamationTriangle, FaLink } from 'react-icons/fa';
-import { Wrapper as MenuWrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
 import { Paginator } from '../../Paginator';
-import classNames from 'classnames';
-import { pluralize } from '../../utils';
-import { v4 as uuidv4 } from 'uuid';
-import * as d3 from 'd3';
-import { ConditionalRowStyle } from '../types';
-import { DownloadDropdown } from '../../DownloadDropdown';
+import { FaCaretDown } from 'react-icons/fa';
 
 /**
  * Component for rendering data returned within a SearchUI component
@@ -25,14 +16,8 @@ interface Props {
 export const SearchUIDataTable: React.FC<Props> = (props) => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
-  const [titleHover, setTitleHover] = useState(false);
   const [toggleClearRows, setToggleClearRows] = useState(false);
-  const [columns, setColumns] = useState(state.columns.filter((c) => !c.hidden));
   const tableRef = useRef<HTMLDivElement>(null);
-  const [allCollumnsSelected, setAllCollumnsSelected] = useState(() => {
-    const anyNotSelected = columns.find((col) => col.omit);
-    return !anyNotSelected;
-  });
 
   const handlePageChange = (page: number) => {
     /** Scroll table back to top when page changes */
@@ -40,11 +25,6 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
       tableRef.current.children[0].scrollTop = 0;
     }
     actions.setPage(page);
-    setToggleClearRows(!toggleClearRows);
-  };
-
-  const handlePerRowsChange = (perPage: number) => {
-    actions.setResultsPerPage(perPage);
     setToggleClearRows(!toggleClearRows);
   };
 
@@ -65,31 +45,8 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
       rowsPerPage={state.resultsPerPage}
       currentPage={state.page}
       onChangePage={handlePageChange}
-      onChangeRowsPerPage={handlePerRowsChange}
     />
   );
-
-  const NoDataMessage = () => {
-    if (state.error) {
-      return (
-        <div className="react-data-table-message">
-          <p>
-            <FaExclamationTriangle /> There was an error with your search.
-          </p>
-          <p>
-            You may have entered an invalid search value. Otherwise, the API may be temporarily
-            unavailable.
-          </p>
-        </div>
-      );
-    } else {
-      return (
-        <div className="react-data-table-message">
-          <p>No records match your search criteria</p>
-        </div>
-      );
-    }
-  };
 
   const conditionalRowStyles: any[] = state.conditionalRowStyles!.map((c) => {
     c.when = (row) => row[c.selector] === c.value;
@@ -98,7 +55,7 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
 
   return (
     <div className="mpc-search-ui-data-table">
-      {state.resultsPerPage > 15 && <CustomPaginator />}
+      {state.results.length > 15 && <CustomPaginator />}
       <div className="columns react-data-table-outer-container">
         <div
           data-testid="react-data-table-container"
@@ -128,7 +85,6 @@ export const SearchUIDataTable: React.FC<Props> = (props) => {
               },
             }}
             conditionalRowStyles={conditionalRowStyles}
-            noDataComponent={<NoDataMessage />}
             selectableRows={state.selectableRows}
             onSelectedRowsChange={handleSelectedRowsChange}
             clearSelectedRows={toggleClearRows}

--- a/src/components/search/SearchUI/SearchUIDataTable/SearchUIDataTable.tsx
+++ b/src/components/search/SearchUI/SearchUIDataTable/SearchUIDataTable.tsx
@@ -5,15 +5,11 @@ import { Paginator } from '../../Paginator';
 import { FaCaretDown } from 'react-icons/fa';
 
 /**
- * Component for rendering data returned within a SearchUI component
- * Table data and interactions are hooked up to the SearchUIContext state and actions
+ * Component for rendering SearchUI results in the table view
+ * Uses react-data-table-component to render results based
+ * on the current state of the SearchUIContext
  */
-
-interface Props {
-  className?: string;
-}
-
-export const SearchUIDataTable: React.FC<Props> = (props) => {
+export const SearchUIDataTable: React.FC = () => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
   const [toggleClearRows, setToggleClearRows] = useState(false);

--- a/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
+++ b/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
+import { Paginator } from '../../Paginator';
+import { DataCard } from '../../DataCard';
+import { getCustomCardComponent } from '../utils';
+import { SearchUIDataTable } from '../SearchUIDataTable';
+import { SearchUIDataCards } from '../SearchUIDataCards';
+import { FaExclamationTriangle } from 'react-icons/fa';
+
+/**
+ * Component for rendering data returned within a SearchUI component
+ * Table data and interactions are hooked up to the SearchUIContext state and actions
+ */
+
+interface Props {
+  className?: string;
+}
+
+export const SearchUIDataView: React.FC<Props> = (props) => {
+  const state = useSearchUIContext();
+
+  const getDataView = () => {
+    if (state.error) {
+      return (
+        <div className="react-data-table-message">
+          <p>
+            <FaExclamationTriangle /> There was an error with your search.
+          </p>
+          <p>
+            You may have entered an invalid search value. Otherwise, the API may be temporarily
+            unavailable.
+          </p>
+        </div>
+      );
+    } else if (!state.results || state.results.length === 0) {
+      return (
+        <div className="react-data-table-message">
+          <p>No records match your search criteria</p>
+        </div>
+      );
+    } else if (state.view === 'table') {
+      return <SearchUIDataTable />;
+    } else if (state.view === 'cards') {
+      return <SearchUIDataCards />;
+    } else {
+      return null;
+    }
+  };
+
+  return <div className="mpc-search-ui-data-view">{getDataView()}</div>;
+};

--- a/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
+++ b/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
@@ -8,15 +8,11 @@ import { SearchUIDataCards } from '../SearchUIDataCards';
 import { FaExclamationTriangle } from 'react-icons/fa';
 
 /**
- * Component for rendering data returned within a SearchUI component
- * Table data and interactions are hooked up to the SearchUIContext state and actions
+ * Component for rendering SearchUI data in a certain view
+ * based on the current view state, error state, and number
+ * of results.
  */
-
-interface Props {
-  className?: string;
-}
-
-export const SearchUIDataView: React.FC<Props> = (props) => {
+export const SearchUIDataView: React.FC = () => {
   const state = useSearchUIContext();
 
   const getDataView = () => {

--- a/src/components/search/SearchUI/SearchUIDataView/index.tsx
+++ b/src/components/search/SearchUI/SearchUIDataView/index.tsx
@@ -1,0 +1,1 @@
+export { SearchUIDataView } from './SearchUIDataView';

--- a/src/components/search/SearchUI/types.tsx
+++ b/src/components/search/SearchUI/types.tsx
@@ -100,3 +100,8 @@ export enum ColumnFormat {
   SPACEGROUP_SYMBOL = 'SPACEGROUP_SYMBOL',
   POINTGROUP = 'POINTGROUP',
 }
+
+export enum SearchUIView {
+  TABLE = 'table',
+  CARDS = 'cards',
+}

--- a/src/components/search/SearchUI/utils.tsx
+++ b/src/components/search/SearchUI/utils.tsx
@@ -417,7 +417,13 @@ export const mapInputTypeToField = (
   return allowedInputTypesMap[inputType].field;
 };
 
-const customCardsMap = {
+export enum CustomCardType {
+  SYNTHESIS = 'synthesis',
+}
+
+export type CustomCardTypeMap = Partial<Record<CustomCardType, any>>;
+
+const customCardsMap: CustomCardTypeMap = {
   synthesis: SynthesisRecipeCard,
 };
 

--- a/src/components/search/SearchUI/utils.tsx
+++ b/src/components/search/SearchUI/utils.tsx
@@ -17,6 +17,7 @@ import { MaterialsInputTypesMap, validateElements } from '../MaterialsInput/util
 import { useMediaQuery } from 'react-responsive';
 import { SearchUIProps } from '.';
 import { MaterialsInputBox } from '../MaterialsInput/MaterialsInputBox';
+import { SynthesisRecipeCard } from '../SynthesisRecipeCard';
 
 const getRowValueFromSelectorString = (selector: string, row: any) => {
   const selectors = selector.split('.');
@@ -414,4 +415,16 @@ export const mapInputTypeToField = (
   allowedInputTypesMap: MaterialsInputTypesMap
 ) => {
   return allowedInputTypesMap[inputType].field;
+};
+
+const customCardsMap = {
+  synthesis: SynthesisRecipeCard,
+};
+
+export const getCustomCardComponent = (cardType?: string) => {
+  if (cardType && customCardsMap.hasOwnProperty(cardType)) {
+    return customCardsMap[cardType];
+  } else {
+    return null;
+  }
 };

--- a/src/components/search/SortDropdown/SortDropdown.tsx
+++ b/src/components/search/SortDropdown/SortDropdown.tsx
@@ -1,0 +1,110 @@
+import classNames from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { Wrapper as MenuWrapper, Button, Menu, MenuItem } from 'react-aria-menubutton';
+import { FaAngleDown, FaSort, FaSortDown, FaSortUp } from 'react-icons/fa';
+import { sortDynamic } from '../utils';
+
+/**
+ * Component for rendering and filtering a list of citations in bibjson or crossref format
+ * Expects bibjson in the format output by the bibtexparser library (https://bibtexparser.readthedocs.io/en/v1.1.0/tutorial.html#)
+ * Expects crossref in the format returned by the Crossref API
+ */
+
+interface Props {
+  id?: string;
+  setProps?: (value: any) => any;
+  className?: string;
+  sortValues: any[];
+  setSortValues?: (value: any) => any;
+  sortOptions: DropdownItem[];
+  sortField?: string;
+  setSortField: (value: any) => any;
+  sortAscending?: boolean;
+  setSortAscending: (value: any) => any;
+  sortFn?: (field: string, asc: boolean) => any;
+}
+
+export interface DropdownItem {
+  label: string;
+  value: string;
+}
+
+export const SortDropdown: React.FC<Props> = ({
+  sortAscending = false,
+  sortFn = sortDynamic,
+  sortOptions,
+  sortField = sortOptions[0].value,
+  ...otherProps
+}) => {
+  const props = { sortAscending, sortFn, sortOptions, sortField, ...otherProps };
+
+  const getLabelByValue = (value: string) => {
+    const option = props.sortOptions.find((d) => d.value === value);
+    return option?.label;
+  };
+
+  const handleSortFieldChange = (field: string) => {
+    props.setSortField(field);
+  };
+
+  const handleSort = () => {
+    if (props.setSortValues) {
+      const sortedValues = props.sortValues.sort(
+        props.sortFn(props.sortField, props.sortAscending)
+      );
+      props.setSortValues([...sortedValues]);
+    } else {
+      props.sortFn(props.sortField, props.sortAscending);
+    }
+  };
+
+  const handleSortDirection = () => {
+    props.setSortAscending(!props.sortAscending);
+  };
+
+  useEffect(() => {
+    handleSort();
+  }, [props.sortAscending, props.sortField]);
+
+  return (
+    <div
+      id={props.id}
+      data-testid="mpc-sort-dropdown"
+      className={classNames('mpc-sort-dropdown field has-addons', props.className)}
+    >
+      <div className="control">
+        <button
+          className="mpc-sort-button button"
+          onClick={handleSortDirection}
+          aria-label={
+            props.sortAscending ? 'Sorted in ascending order' : 'Sorted in descending order'
+          }
+        >
+          <FaSort className="mpc-bib-filter-sort-icon-bg" />
+          {props.sortAscending ? <FaSortUp /> : <FaSortDown />}
+        </button>
+      </div>
+      <div className="control">
+        <MenuWrapper className="dropdown is-active is-right" onSelection={handleSortFieldChange}>
+          <div className="dropdown-trigger">
+            <Button className="button">
+              <span>Sort: {getLabelByValue(props.sortField)}</span>
+              <span className="icon">
+                <FaAngleDown />
+              </span>
+            </Button>
+          </div>
+          <Menu className="dropdown-menu">
+            <ul className="dropdown-content">
+              {props.sortOptions.map((item, i) => (
+                <MenuItem key={`sort-dropdown-item-${i}`} value={item.value}>
+                  <li className="dropdown-item">{item.label}</li>
+                </MenuItem>
+              ))}
+            </ul>
+          </Menu>
+        </MenuWrapper>
+      </div>
+    </div>
+  );
+};

--- a/src/components/search/SortDropdown/index.tsx
+++ b/src/components/search/SortDropdown/index.tsx
@@ -1,0 +1,1 @@
+export { SortDropdown } from './SortDropdown';

--- a/src/components/search/SynthesisRecipeCard/SynthesisRecipeCard.tsx
+++ b/src/components/search/SynthesisRecipeCard/SynthesisRecipeCard.tsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+
+interface Props {
+  id?: string;
+  setProps?: (value: any) => any;
+  className?: string;
+  data: any;
+}
+
+export const SynthesisRecipeCard: React.FC<Props> = (props) => {
+  return (
+    <div className={classNames('mpc-synthesis-recipe-card', props.className)}>
+      <div>{props.data.formula_pretty}</div>
+    </div>
+  );
+};

--- a/src/components/search/SynthesisRecipeCard/index.tsx
+++ b/src/components/search/SynthesisRecipeCard/index.tsx
@@ -1,0 +1,1 @@
+export { SynthesisRecipeCard } from './SynthesisRecipeCard';

--- a/src/components/search/utils.tsx
+++ b/src/components/search/utils.tsx
@@ -282,3 +282,42 @@ export const getPageCount = (totalResults: number, resultsPerPage: number) => {
     return Math.ceil(totalResults / resultsPerPage);
   }
 };
+
+export const sortDynamic = (field, asc?) => {
+  const sortDirection = asc ? 1 : -1;
+  return (a, b) => {
+    const result = a[field] < b[field] ? -1 : a[field] > b[field] ? 1 : 0;
+    return result * sortDirection;
+  };
+};
+
+export const sortCrossref = (field, asc?) => {
+  const sortDirection = asc ? 1 : -1;
+  return (a, b) => {
+    let result = 0;
+    switch (field) {
+      case 'year':
+        result =
+          a.created.timestamp < b.created.timestamp
+            ? -1
+            : a.created.timestamp > b.created.timestamp
+            ? 1
+            : 0;
+        break;
+      case 'author':
+        result =
+          a.author[0].family < b.author[0].family
+            ? -1
+            : a.author[0].family > b.author[0].family
+            ? 1
+            : 0;
+        break;
+      case 'title':
+        result = a.title[0] < b.title[0] ? -1 : a.title[0] > b.title[0] ? 1 : 0;
+        break;
+      default:
+        result = a[field] < b[field] ? -1 : a[field] > b[field] ? 1 : 0;
+    }
+    return result * sortDirection;
+  };
+};

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SearchUI } from '../../components/search/SearchUI';
-import { FilterGroup } from '../../components/search/SearchUI/types';
+import { FilterGroup, SearchUIView } from '../../components/search/SearchUI/types';
 import filterGroups from './filterGroups.json';
 import columns from './columns.json';
 
@@ -13,7 +13,19 @@ export const MaterialsExplorer: React.FC = () => {
     <>
       <h1 className="title">Materials Explorer</h1>
       <SearchUI
-        view="cards"
+        view={SearchUIView.CARDS}
+        // customCardType="synthesis"
+        allowViewSwitching
+        cardOptions={{
+          imageBaseURL: 'https://next-gen.materialsproject.org/static/structures/',
+          imageKey: 'material_id',
+          levelOneKey: 'material_id',
+          levelTwoKey: 'formula_pretty',
+          levelThreeKeys: [
+            { key: 'energy_above_hull', label: 'Energy Above Hull' },
+            { key: 'formation_energy_per_atom', label: 'Formation Energy' },
+          ],
+        }}
         resultLabel="material"
         columns={columns}
         filterGroups={filterGroups as FilterGroup[]}

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -13,6 +13,7 @@ export const MaterialsExplorer: React.FC = () => {
     <>
       <h1 className="title">Materials Explorer</h1>
       <SearchUI
+        view="cards"
         resultLabel="material"
         columns={columns}
         filterGroups={filterGroups as FilterGroup[]}

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -13,7 +13,7 @@ export const MaterialsExplorer: React.FC = () => {
     <>
       <h1 className="title">Materials Explorer</h1>
       <SearchUI
-        view={SearchUIView.CARDS}
+        view={SearchUIView.TABLE}
         // customCardType="synthesis"
         allowViewSwitching
         cardOptions={{
@@ -38,7 +38,6 @@ export const MaterialsExplorer: React.FC = () => {
         apiKey={undefined}
         sortField="energy_above_hull"
         sortAscending={true}
-        selectableRows={true}
         searchBarTooltip="Type in a comma-separated list of element symbols (e.g. Ga, N), a chemical formula (e.g. C3N), or a material id (e.g. mp-10152). You can also click elements on the periodic table to add them to your search."
         searchBarPlaceholder="Search by elements, formula, or mp-id"
         searchBarErrorMessage="Please enter a valid formula (e.g. CeZn5), list of elements (e.g. Ce, Zn or Ce-Zn), or ID (e.g. mp-394 or mol-54330)."


### PR DESCRIPTION
- New `SearchUI` prop `view`
  - Let's you set the default view for the results
  - Can be either "table" or "cards"
- New `SearchUI` prop `allowViewSwitching`
  - Enables/disables the ability to switch between card and table views
- New `SearchUI` prop `customCardType`
  - Change type of card displayed in the card results view
  - Must be one of the values in the `CustomCardType` enum
  - To add a custom card type, head to `SearchUI/utils` and add the name of the type to the `CustomCardType` enum, then add a property in `customCardsMap` using the same name you used for the type, then provide your custom component as the value.
  - Note: custom card components must have these 3 (and only these 3) props: "data", "id", "className"
  - The "data" prop will be the individual row of data in the results for populating the card's content.
  - Note: this component will be displayed in the "card" view, so the `SearchUI` component must have either `allowViewSwitching = true` or `view = "cards"`
