### PR TITLE
Modify how to implement custom SearchUI views

### DIFF
--- a/src/components/search/SearchUI/SearchUI.test.tsx
+++ b/src/components/search/SearchUI/SearchUI.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen, cleanup } from '@testing-library/react';
 import { SearchUI, SearchUIProps } from '.';
-import { FilterGroup, SearchUIView } from './types';
+import { FilterGroup } from './types';
 import filterGroups from '../../../views/MaterialsExplorer/filterGroups.json';
 import columns from '../../../views/MaterialsExplorer/columns.json';
 import { materialsByIdQuery } from '../../../mocks/constants/materialsById';

--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { SearchUIContextProvider } from './SearchUIContextProvider';
 import { SearchUIFilters } from './SearchUIFilters';
 import { SearchUIDataTable } from './SearchUIDataTable';
-import { Column, FilterGroup, ConditionalRowStyle, SearchUIView } from './types';
+import { Column, FilterGroup, ConditionalRowStyle, SearchUIViewType } from './types';
 import { SearchUISearchBar } from './SearchUISearchBar';
 import './SearchUI.css';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -11,7 +11,6 @@ import { MaterialsInputTypesMap } from '../MaterialsInput/utils';
 import { SearchUIDataHeader } from './SearchUIDataHeader';
 import { SearchUIDataCards } from './SearchUIDataCards';
 import { SearchUIDataView } from './SearchUIDataView';
-import { CustomCardType } from './utils';
 import { PeriodicTableMode } from '../MaterialsInput/MaterialsInput';
 
 export interface SearchUIProps {
@@ -220,27 +219,20 @@ export interface SearchUIProps {
 
   /**
    * Set the initial results view to one of the preset
-   * SearchUI views: 'table' or 'cards'
+   * SearchUI views: 'table', 'cards', or 'synthesis'
+   *
+   * To add a new view type, head to SearchUI/types and add the name of the type to the
+   * SearchUIViewType enum, then add a property in searchUIViewsMap using the same name
+   * you used for the type, then provide your custom view component as the value.
+   * The view component should consume the SearchUIContext state using the useSearchUIContext hook.
+   * See SearchUIDataTable or SearchUIDataCards for example view components.
    */
-  view?: SearchUIView;
+  view?: SearchUIViewType;
 
   /**
    * Optionally enable/disable switching between SearchUI result views
    */
   allowViewSwitching?: boolean;
-
-  /**
-   * Change type of card displayed in the card results view
-   * Must be one of the values in the CustomCardType enum
-   *
-   * To add a custom card type, head to SearchUI/utils and add the name of the type to the
-   * CustomCardType enum, then add a property in customCardsMap using the same name
-   * you used for the type, then provide your custom component as the value.
-   *
-   * Note that custom card components must have these 3 (and only these 3) props: "data", "id", "className"
-   * The "data" prop will be the individual row of data in the results for populating the card's content.
-   */
-  customCardType?: CustomCardType;
 
   /**
    * Set of options for configuring what is displayed in the result cards
@@ -296,7 +288,7 @@ export const SearchUI: React.FC<SearchUIProps> = (props) => {
 };
 
 SearchUI.defaultProps = {
-  view: SearchUIView.TABLE,
+  view: SearchUIViewType.TABLE,
   resultLabel: 'results',
   hasSearchBar: true,
   conditionalRowStyles: [],

--- a/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
+++ b/src/components/search/SearchUI/SearchUIDataCards/SearchUIDataCards.tsx
@@ -2,25 +2,16 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
 import { Paginator } from '../../Paginator';
 import { DataCard } from '../../DataCard';
-import { getCustomCardComponent } from '../utils';
 
 /**
  * Component for rendering SearchUI results in the cards view
  * Will use the DataCard component to render results as a grid
  * of cards where each shows an image and a few select data properties.
- * If a customCardType is supplied to the SearchUI, this component
- * will use the customCardMap to find a different component to render the cards.
  */
 export const SearchUIDataCards: React.FC = () => {
   const state = useSearchUIContext();
   const actions = useSearchUIContextActions();
-  const tableRef = useRef<HTMLDivElement>(null);
-  const CustomCardComponent = getCustomCardComponent(state.customCardType);
   const handlePageChange = (page: number) => {
-    /** Scroll table back to top when page changes */
-    if (tableRef.current) {
-      tableRef.current.children[0].scrollTop = 0;
-    }
     actions.setPage(page);
   };
 
@@ -34,42 +25,26 @@ export const SearchUIDataCards: React.FC = () => {
   );
 
   return (
-    <div className="mpc-search-ui-data-cards">
+    <div data-testid="mpc-search-ui-data-cards" className="mpc-search-ui-data-cards">
       <CustomPaginator />
-      <div
-        data-testid="mpc-search-ui-data-cards-container"
-        className="mpc-search-ui-data-cards-container"
-        ref={tableRef}
-      >
-        {state.results.map((d, i) => {
-          if (CustomCardComponent) {
-            return (
-              <CustomCardComponent
-                key={`mpc-data-card-${i}`}
-                className="mpc-search-ui-custom-card"
-                data={d}
-              />
-            );
-          } else {
-            return (
-              <DataCard
-                key={`mpc-data-card-${i}`}
-                className="box mpc-search-ui-data-card"
-                data={d}
-                levelOneKey={state.cardOptions.levelOneKey}
-                levelTwoKey={state.cardOptions.levelTwoKey}
-                levelThreeKeys={state.cardOptions.levelThreeKeys}
-                leftComponent={
-                  <figure className="image is-128x128">
-                    <img
-                      src={state.cardOptions.imageBaseURL + d[state.cardOptions.imageKey] + '.png'}
-                    />
-                  </figure>
-                }
-              />
-            );
-          }
-        })}
+      <div className="mpc-search-ui-data-cards-container">
+        {state.results.map((d, i) => (
+          <DataCard
+            key={`mpc-data-card-${i}`}
+            className="box mpc-search-ui-data-card"
+            data={d}
+            levelOneKey={state.cardOptions.levelOneKey}
+            levelTwoKey={state.cardOptions.levelTwoKey}
+            levelThreeKeys={state.cardOptions.levelThreeKeys}
+            leftComponent={
+              <figure className="image is-128x128">
+                <img
+                  src={state.cardOptions.imageBaseURL + d[state.cardOptions.imageKey] + '.png'}
+                />
+              </figure>
+            }
+          />
+        ))}
       </div>
       <CustomPaginator />
     </div>

--- a/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
+++ b/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
@@ -1,10 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
-import { Paginator } from '../../Paginator';
-import { DataCard } from '../../DataCard';
-import { getCustomCardComponent } from '../utils';
-import { SearchUIDataTable } from '../SearchUIDataTable';
-import { SearchUIDataCards } from '../SearchUIDataCards';
+import React from 'react';
+import { useSearchUIContext } from '../SearchUIContextProvider';
+import { searchUIViewsMap } from '../types';
 import { FaExclamationTriangle } from 'react-icons/fa';
 
 /**
@@ -34,12 +30,9 @@ export const SearchUIDataView: React.FC = () => {
           <p>No records match your search criteria</p>
         </div>
       );
-    } else if (state.view === 'table') {
-      return <SearchUIDataTable />;
-    } else if (state.view === 'cards') {
-      return <SearchUIDataCards />;
     } else {
-      return null;
+      const SearchUIViewComponent = searchUIViewsMap[state.view!];
+      return <SearchUIViewComponent />;
     }
   };
 

--- a/src/components/search/SearchUI/SearchUISynthesisRecipeCards/SearchUISynthesisRecipeCards.tsx
+++ b/src/components/search/SearchUI/SearchUISynthesisRecipeCards/SearchUISynthesisRecipeCards.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useSearchUIContext, useSearchUIContextActions } from '../SearchUIContextProvider';
+import { Paginator } from '../../Paginator';
+
+/**
+ *
+ */
+export const SearchUISynthesisRecipeCards: React.FC = () => {
+  const state = useSearchUIContext();
+  const actions = useSearchUIContextActions();
+  const handlePageChange = (page: number) => {
+    actions.setPage(page);
+  };
+
+  const CustomPaginator = () => (
+    <Paginator
+      rowCount={state.totalResults}
+      rowsPerPage={state.resultsPerPage}
+      currentPage={state.page}
+      onChangePage={handlePageChange}
+    />
+  );
+
+  return (
+    <div data-testid="mpc-synthesis-recipe-cards" className="mpc-synthesis-recipe-cards">
+      <CustomPaginator />
+      <div className="mpc-synthesis-recipe-cards-container">
+        {state.results.map((d, i) => (
+          // Custom result cards
+          <div></div>
+        ))}
+      </div>
+      <CustomPaginator />
+    </div>
+  );
+};

--- a/src/components/search/SearchUI/SearchUISynthesisRecipeCards/index.tsx
+++ b/src/components/search/SearchUI/SearchUISynthesisRecipeCards/index.tsx
@@ -1,0 +1,1 @@
+export { SearchUISynthesisRecipeCards } from './SearchUISynthesisRecipeCards';

--- a/src/components/search/SearchUI/types.tsx
+++ b/src/components/search/SearchUI/types.tsx
@@ -1,5 +1,8 @@
 import { MaterialsInputType } from '../MaterialsInput';
 import { SearchUIProps } from './SearchUI';
+import { SearchUIDataCards } from './SearchUIDataCards';
+import { SearchUIDataTable } from './SearchUIDataTable';
+import { SearchUISynthesisRecipeCards } from './SearchUISynthesisRecipeCards';
 
 export enum FilterId {
   ELEMENTS = 'elements',
@@ -101,7 +104,16 @@ export enum ColumnFormat {
   POINTGROUP = 'POINTGROUP',
 }
 
-export enum SearchUIView {
+export enum SearchUIViewType {
   TABLE = 'table',
   CARDS = 'cards',
+  SYNTHESIS = 'synthesis',
 }
+
+export type SearchUIViewTypeMap = Partial<Record<SearchUIViewType, any>>;
+
+export const searchUIViewsMap: SearchUIViewTypeMap = {
+  table: SearchUIDataTable,
+  cards: SearchUIDataCards,
+  synthesis: SearchUISynthesisRecipeCards,
+};

--- a/src/components/search/SearchUI/utils.tsx
+++ b/src/components/search/SearchUI/utils.tsx
@@ -9,7 +9,15 @@ import {
   spaceGroupNumberOptions,
   spaceGroupSymbolOptions,
 } from '../utils';
-import { ActiveFilter, Column, ColumnFormat, FilterGroup, FilterType, SearchState } from './types';
+import {
+  ActiveFilter,
+  Column,
+  ColumnFormat,
+  FilterGroup,
+  FilterType,
+  SearchState,
+  SearchUIViewTypeMap,
+} from './types';
 import { Link } from '../../navigation/Link';
 import { spaceGroups } from '../../../constants/spaceGroups';
 import { MaterialsInputType } from '../MaterialsInput';
@@ -18,6 +26,9 @@ import { useMediaQuery } from 'react-responsive';
 import { SearchUIProps } from '.';
 import { MaterialsInputBox } from '../MaterialsInput/MaterialsInputBox';
 import { SynthesisRecipeCard } from '../SynthesisRecipeCard';
+import { SearchUIDataTable } from './SearchUIDataTable';
+import { SearchUIDataCards } from './SearchUIDataCards';
+import { SearchUISynthesisRecipeCards } from './SearchUISynthesisRecipeCards';
 
 const getRowValueFromSelectorString = (selector: string, row: any) => {
   const selectors = selector.split('.');
@@ -415,22 +426,4 @@ export const mapInputTypeToField = (
   allowedInputTypesMap: MaterialsInputTypesMap
 ) => {
   return allowedInputTypesMap[inputType].field;
-};
-
-export enum CustomCardType {
-  SYNTHESIS = 'synthesis',
-}
-
-export type CustomCardTypeMap = Partial<Record<CustomCardType, any>>;
-
-const customCardsMap: CustomCardTypeMap = {
-  synthesis: SynthesisRecipeCard,
-};
-
-export const getCustomCardComponent = (cardType?: string) => {
-  if (cardType && customCardsMap.hasOwnProperty(cardType)) {
-    return customCardsMap[cardType];
-  } else {
-    return null;
-  }
 };

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { SearchUI } from '../../components/search/SearchUI';
-import { FilterGroup, SearchUIView } from '../../components/search/SearchUI/types';
+import { FilterGroup } from '../../components/search/SearchUI/types';
 import filterGroups from './filterGroups.json';
 import columns from './columns.json';
-import { CustomCardType } from '../../components/search/SearchUI/utils';
+import { SearchUIViewType } from '../../components/search/SearchUI/types';
 import { PeriodicTableMode } from '../../components/search/MaterialsInput/MaterialsInput';
 
 /**
@@ -15,8 +15,7 @@ export const MaterialsExplorer: React.FC = () => {
     <>
       <h1 className="title">Materials Explorer</h1>
       <SearchUI
-        view={SearchUIView.TABLE}
-        customCardType={CustomCardType.SYNTHESIS}
+        view={SearchUIViewType.TABLE}
         allowViewSwitching
         cardOptions={{
           imageBaseURL: 'https://next-gen.materialsproject.org/static/structures/',


### PR DESCRIPTION
- Removed the `customCardType` prop
- New views should now be added to the `SearchUIViewType` enum and then can be set using the `view` prop on the `SearchUI` component
- Custom views are now handled at the view level to maximize customizability and ensure they aren't constrained by the existing `mpc-search-ui-data-card-container` styles
- Added a template for the view component `SearchUISynthesisRecipeCards`