### PR TITLE
Add prop for disabling sort menu and hide column menu when not in table view

### DIFF
--- a/src/components/search/SearchUI/SearchUI.tsx
+++ b/src/components/search/SearchUI/SearchUI.tsx
@@ -111,12 +111,19 @@ export interface SearchUIProps {
   apiKey?: string;
 
   /**
-   * A noun in singular form to describe what a result represents (default: "result")
+   * A noun in singular form to describe what a result represents
    * e.g. "material"
    * Note that only some special plural mappings are handled automatically (e.g. battery -> batteries)
    * In all other cases, an "s" is appended to resultLabel
+   * @default "result"
    */
   resultLabel?: string;
+
+  /**
+   * Optionally include/exclude the top search bar
+   * @default true
+   */
+  hasSearchBar?: boolean;
 
   /**
    * Optionally add a help icon with a tooltip in the search bar
@@ -164,8 +171,15 @@ export interface SearchUIProps {
    * "toggle": render a button for toggling visibility of periodic table
    * "focus": show periodic table when input is focuses, hide on blur
    * "none": never show the periodic table for this input
+   * @default "toggle"
    */
   searchBarPeriodicTableMode?: PeriodicTableMode;
+
+  /**
+   * Optionally include/exclude the menu for dynamically controlling sort options
+   * @default true
+   */
+  hasSortMenu?: boolean;
 
   /**
    * Optionally include a field to sort by on initial load
@@ -178,12 +192,6 @@ export interface SearchUIProps {
    * True for ascending, False for descending
    */
   sortAscending?: boolean;
-
-  /**
-   * Optionally include/exclude the top search bar
-   * Defaults to true
-   */
-  hasSearchBar?: boolean;
 
   /**
    * List of conditions for styling rows based on a property (selector) and a value
@@ -226,6 +234,7 @@ export interface SearchUIProps {
    * you used for the type, then provide your custom view component as the value.
    * The view component should consume the SearchUIContext state using the useSearchUIContext hook.
    * See SearchUIDataTable or SearchUIDataCards for example view components.
+   * @default "table"
    */
   view?: SearchUIViewType;
 
@@ -290,6 +299,7 @@ export const SearchUI: React.FC<SearchUIProps> = (props) => {
 SearchUI.defaultProps = {
   view: SearchUIViewType.TABLE,
   resultLabel: 'results',
+  hasSortMenu: true,
   hasSearchBar: true,
   conditionalRowStyles: [],
   searchBarPeriodicTableMode: PeriodicTableMode.TOGGLE,

--- a/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
+++ b/src/components/search/SearchUI/SearchUIDataHeader/SearchUIDataHeader.tsx
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as d3 from 'd3';
 import { SortDropdown } from '../../SortDropdown';
 import { DropdownItem } from '../../SortDropdown/SortDropdown';
+import { SearchUIViewType } from '../types';
 
 const componentHtmlId = uuidv4();
 
@@ -146,74 +147,75 @@ export const SearchUIDataHeader: React.FC = () => {
     }
   };
 
-  const columnsMenu = (
-    <MenuWrapper
-      data-testid="columns-menu"
-      className="dropdown is-right is-active"
-      closeOnSelection={false}
-    >
-      <div className="dropdown-trigger">
-        <Button className="button">
-          <span>Columns</span>
-          <span className="icon">
-            <FaAngleDown />
-          </span>
-        </Button>
-      </div>
-      <Menu className="dropdown-menu">
-        <ul className="dropdown-content">
-          <MenuItem>
-            <li className="dropdown-item">
-              <label className="checkbox is-block">
-                <input
-                  type="checkbox"
-                  role="checkbox"
-                  checked={allCollumnsSelected}
-                  aria-checked={allCollumnsSelected}
-                  /**
-                   * Use key-up event to allow toggling with the space bar
-                   * Must use key-up instead of key-down to prevent double-firing in Firefox
-                   */
-                  onKeyUp={(e) => {
-                    e.preventDefault();
-                    if (e.keyCode === 32) toggleAllColumns();
-                  }}
-                  onChange={(e) => toggleAllColumns()}
-                />
-                <span>
-                  <strong>Select all</strong>
-                </span>
-              </label>
-            </li>
-          </MenuItem>
-          {columns.map((col, i) => (
-            <MenuItem key={i}>
+  const columnsMenu =
+    state.view === SearchUIViewType.TABLE ? (
+      <MenuWrapper
+        data-testid="columns-menu"
+        className="dropdown is-right is-active"
+        closeOnSelection={false}
+      >
+        <div className="dropdown-trigger">
+          <Button className="button">
+            <span>Columns</span>
+            <span className="icon">
+              <FaAngleDown />
+            </span>
+          </Button>
+        </div>
+        <Menu className="dropdown-menu">
+          <ul className="dropdown-content">
+            <MenuItem>
               <li className="dropdown-item">
                 <label className="checkbox is-block">
                   <input
                     type="checkbox"
                     role="checkbox"
-                    checked={!col.omit}
-                    aria-checked={!col.omit}
+                    checked={allCollumnsSelected}
+                    aria-checked={allCollumnsSelected}
                     /**
                      * Use key-up event to allow toggling with the space bar
                      * Must use key-up instead of key-down to prevent double-firing in Firefox
                      */
                     onKeyUp={(e) => {
                       e.preventDefault();
-                      if (e.keyCode === 32) toggleColumn(i);
+                      if (e.keyCode === 32) toggleAllColumns();
                     }}
-                    onChange={(e) => toggleColumn(i)}
+                    onChange={(e) => toggleAllColumns()}
                   />
-                  <span>{col.nameString}</span>
+                  <span>
+                    <strong>Select all</strong>
+                  </span>
                 </label>
               </li>
             </MenuItem>
-          ))}
-        </ul>
-      </Menu>
-    </MenuWrapper>
-  );
+            {columns.map((col, i) => (
+              <MenuItem key={i}>
+                <li className="dropdown-item">
+                  <label className="checkbox is-block">
+                    <input
+                      type="checkbox"
+                      role="checkbox"
+                      checked={!col.omit}
+                      aria-checked={!col.omit}
+                      /**
+                       * Use key-up event to allow toggling with the space bar
+                       * Must use key-up instead of key-down to prevent double-firing in Firefox
+                       */
+                      onKeyUp={(e) => {
+                        e.preventDefault();
+                        if (e.keyCode === 32) toggleColumn(i);
+                      }}
+                      onChange={(e) => toggleColumn(i)}
+                    />
+                    <span>{col.nameString}</span>
+                  </label>
+                </li>
+              </MenuItem>
+            ))}
+          </ul>
+        </Menu>
+      </MenuWrapper>
+    ) : null;
 
   const resultsPerPageOptions = [10, 15, 30, 50, 75];
   const resultsPerPageMenu = (
@@ -246,7 +248,7 @@ export const SearchUIDataHeader: React.FC = () => {
     </MenuWrapper>
   );
 
-  const sortMenu = (
+  const sortMenu = state.hasSortMenu ? (
     <SortDropdown
       sortValues={state.results}
       sortOptions={state.columns
@@ -260,9 +262,9 @@ export const SearchUIDataHeader: React.FC = () => {
       setSortAscending={actions.setSortAscending}
       sortFn={actions.setSort}
     />
-  );
+  ) : null;
 
-  const viewSwitcher = (
+  const viewSwitcher = state.allowViewSwitching ? (
     <div className="field has-addons">
       <div className="control">
         <button
@@ -285,7 +287,7 @@ export const SearchUIDataHeader: React.FC = () => {
         </button>
       </div>
     </div>
-  );
+  ) : null;
 
   return (
     <div id={componentHtmlId} className="mpc-search-ui-data-header">
@@ -302,7 +304,7 @@ export const SearchUIDataHeader: React.FC = () => {
           )}
         </div>
         <div className="mpc-search-ui-data-header-controls">
-          {state.allowViewSwitching && viewSwitcher}
+          {viewSwitcher}
           {sortMenu}
           {columnsMenu}
           {resultsPerPageMenu}

--- a/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
+++ b/src/components/search/SearchUI/SearchUIDataView/SearchUIDataView.tsx
@@ -31,7 +31,7 @@ export const SearchUIDataView: React.FC = () => {
         </div>
       );
     } else {
-      const SearchUIViewComponent = searchUIViewsMap[state.view!];
+      const SearchUIViewComponent = searchUIViewsMap[state.view];
       return <SearchUIViewComponent />;
     }
   };

--- a/src/views/MaterialsExplorer/MaterialsExplorer.tsx
+++ b/src/views/MaterialsExplorer/MaterialsExplorer.tsx
@@ -37,6 +37,7 @@ export const MaterialsExplorer: React.FC = () => {
             : undefined
         }
         apiKey={undefined}
+        hasSortMenu={true}
         sortField="energy_above_hull"
         sortAscending={true}
         searchBarTooltip="Type in a comma-separated list of element symbols (e.g. Ga, N), a chemical formula (e.g. C3N), or a material id (e.g. mp-10152). You can also click elements on the periodic table to add them to your search."


### PR DESCRIPTION
- New `SearchUI` prop `hasSortMenu`
- Columns menu will be disabled when `SearchUI` view is not "table" 