### PR TITLE
Tiling fixes

### DIFF
--- a/src/components/crystal-toolkit/scene/Scene.ts
+++ b/src/components/crystal-toolkit/scene/Scene.ts
@@ -522,6 +522,10 @@ export default class Scene {
       return tiles;
     };
 
+    const _alternateTiles = (x: number) => {
+      return (-1) ** (x + 1) * Math.trunc((x + 1) / 2);
+    };
+
     const emptyLattice = [
       [0, 0, 0],
       [0, 0, 0],
@@ -547,7 +551,9 @@ export default class Scene {
         this.arrayOfTileRoots[x][y][z].push(tileRootObject);
 
         let tileOffsets: number[][] = lattice.map((vector: number[], index: number) => {
-          return vector.map((x: number) => x * tile[index]);
+          return vector.map((x: number) => {
+            return x * _alternateTiles(tile[index]);
+          });
         });
         traverseScene(sceneJson, tileRootObject, tileOffsets, '');
       }

--- a/src/components/crystal-toolkit/scene/Scene.ts
+++ b/src/components/crystal-toolkit/scene/Scene.ts
@@ -400,8 +400,8 @@ export default class Scene {
     private debugDOMElement?,
     cameraState?: CameraState
   ) {
-    this.tiling = tiling;
-    this.maxTiling = maxTiling;
+    this.tiling = tiling || 0;
+    this.maxTiling = maxTiling || [0, 0, 0];
     this.arrayOfTileRoots = Scene.getEmptyTilesArray([
       this.maxTiling,
       this.maxTiling,


### PR DESCRIPTION
A couple fixes for tiling behavior of the crystal viewer.

1. I alternate where tiles appear so that we rotate around the rough center of mass
2. I add defaults for tiling and maxTiling in case they aren't set