### PR TITLE
Drop all THREE.scene.dispose()

### DIFF
--- a/src/components/crystal-toolkit/scene/Scene.ts
+++ b/src/components/crystal-toolkit/scene/Scene.ts
@@ -941,7 +941,7 @@ export default class Scene {
     this.removeListener();
     this.debugHelper && this.debugHelper.onDestroy();
     this.inset.onDestroy();
-    this.controls.dispose();
+    this.controls?.dispose();
     disposeSceneHierarchy(this.scene);
     this.scene.dispose();
     if (this.renderer instanceof THREE.WebGLRenderer) {

--- a/src/components/crystal-toolkit/scene/Scene.ts
+++ b/src/components/crystal-toolkit/scene/Scene.ts
@@ -943,7 +943,6 @@ export default class Scene {
     this.inset.onDestroy();
     this.controls?.dispose();
     disposeSceneHierarchy(this.scene);
-    this.scene.dispose();
     if (this.renderer instanceof THREE.WebGLRenderer) {
       this.renderer.forceContextLoss();
       this.renderer.dispose();

--- a/src/components/crystal-toolkit/scene/debug-helper.ts
+++ b/src/components/crystal-toolkit/scene/debug-helper.ts
@@ -122,7 +122,7 @@ export class DebugHelper {
     this.axis && this.scene.remove(this.axis);
     this.grid && this.scene.remove(this.grid);
     this.scene.dispose();
-    this.controls.dispose();
+    this.controls?.dispose();
     this.debugRenderer.forceContextLoss();
     this.debugRenderer.dispose();
     this.debugRenderer.domElement!.parentElement!.removeChild(this.debugRenderer.domElement);

--- a/src/components/crystal-toolkit/scene/debug-helper.ts
+++ b/src/components/crystal-toolkit/scene/debug-helper.ts
@@ -121,7 +121,6 @@ export class DebugHelper {
     this.scene.remove(this.cameraHelper);
     this.axis && this.scene.remove(this.axis);
     this.grid && this.scene.remove(this.grid);
-    this.scene.dispose();
     this.controls?.dispose();
     this.debugRenderer.forceContextLoss();
     this.debugRenderer.dispose();

--- a/src/components/crystal-toolkit/scene/inset-helper.ts
+++ b/src/components/crystal-toolkit/scene/inset-helper.ts
@@ -176,7 +176,6 @@ export class InsetHelper {
 
   public onDestroy() {
     disposeSceneHierarchy(this.scene);
-    // this.scene.dispose();
     // Note ONLY USE THIS PATTERN IN DISPOSAL METHOD
     this.cameraToFollow = (null as unknown) as THREE.Camera;
     this.insetCamera = (null as unknown) as THREE.OrthographicCamera;


### PR DESCRIPTION
```py
import crystal_toolkit.components as ctc
import dash
from dash import html
from pymatgen.core.lattice import Lattice
from pymatgen.core.structure import Structure

app = dash.Dash()

# create our crystal structure using pymatgen
structure = Structure(Lattice.cubic(4.2), ["Na", "K"], [[0, 0, 0], [0.5, 0.5, 0.5]])

# create the Crystal Toolkit component
structure_component = ctc.StructureMoleculeComponent(
    structure, show_controls=False, id="hi"
)

# add the component's layout to our app's layout
my_layout = html.Div([structure_component.layout()])

# as explained in "preamble" section in documentation
ctc.register_crystal_toolkit(app=app, layout=my_layout)
if __name__ == "__main__":
    app.run_server(debug=True, port=8050)
```

raises `Cannot read properties of undefined (reading 'dispose')`

<img width="775" alt="Screenshot 2023-03-21 at 12 21 11" src="https://user-images.githubusercontent.com/30958850/226718298-d57af1ac-e59f-4e5c-97b0-7098d03041d7.png">
