### PR TITLE
Remove console log 'quarternion changed' in CrystalToolkitScene.tsx

### DIFF
--- a/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
+++ b/src/components/crystal-toolkit/CrystalToolkitScene/CrystalToolkitScene.tsx
@@ -463,10 +463,6 @@ export const CrystalToolkitScene: React.FC<CrystalToolkitSceneProps> = ({
         }
       }
     }, [cameraState.position]);
-
-    useEffect(() => {
-      console.log('quarternion changed');
-    }, [cameraState.quaternion]);
   }
 
   /**


### PR DESCRIPTION
We currently spam the browser console on crystal rotations.

![Screenshot 2023-07-21 at 10 50 21 AM](https://github.com/materialsproject/mp-react-components/assets/30958850/b6ed2eb0-b57c-4d45-8715-98bc1d6f9eba)
