### PR TITLE
add structure and attachments fields (react)

### DIFF
--- a/src/components/data-display/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
+++ b/src/components/data-display/SearchUI/SearchUIContextProvider/SearchUIContextProvider.tsx
@@ -63,13 +63,14 @@ export const SearchUIContextProvider: React.FC<SearchState> = ({
     return initFilterGroups(props.filterGroups);
   }, []);
   const columns = useMemo(() => {
-    return initColumns(props.columns, props.disableRichColumnHeaders);
+    return initColumns(props.columns, props.apiEndpoint, props.disableRichColumnHeaders);
   }, []);
   const [state, setState] = useState<SearchState>({
     ...propsWithoutChildren,
     filterGroups,
     columns
   });
+
   /**
    * These default param values are added to the API query if no value is present
    * for that param. These params are omitted from the URL if they are equal to the

--- a/src/components/data-display/SearchUI/types.tsx
+++ b/src/components/data-display/SearchUI/types.tsx
@@ -138,7 +138,8 @@ export enum ColumnFormat {
   RADIO = 'RADIO',
   EMAIL = 'EMAIL',
   TAG = 'TAG',
-  DICT = 'DICT'
+  DICT = 'DICT',
+  CONTRIBS_FILES_DOWNLOAD = 'CONTRIBS_FILES_DOWNLOAD'
 }
 
 /**

--- a/src/utils/table.tsx
+++ b/src/utils/table.tsx
@@ -337,10 +337,7 @@ export const initColumns = (
                     <span className="tag">{sitem.name}</span>
                     <a
                       href={
-                        apiEndpoint.replace('/contributions/', '') +
-                        '/structures/download/gz/?format=json&_fields=id,name,md5,lattice,sites,charge&id=' +
-                        sitem.id +
-                        '&_limit=10&per_page=10'
+                        apiEndpoint.replace('contribs-api', 'contribs') + 'component/' + sitem.id
                       }
                     >
                       <FaDownload className="mr-1" />
@@ -349,31 +346,16 @@ export const initColumns = (
                 );
               }
               return <span>{out}</span>;
-            } else if (c.formatOptions === 'attachemnts' && row.attachemnts) {
+            } else if (c.formatOptions === 'attachments' && row.attachments) {
               let out: any[] = [];
-              for (let aitem of row.attachemnts) {
+              for (let aitem of row.attachments) {
                 out.push(
                   <span key={Math.random()}>
                     <span className="tag">{aitem.name}</span>
                     <a
-                      onClick={() => {
-                        axios
-                          .get(
-                            apiEndpoint.replace('/contributions/', '') +
-                              '/attachments/?_fields=_all&id=' +
-                              aitem.id,
-                            {}
-                          )
-                          .then((result) => {
-                            const link = document.createElement('a');
-                            link.href =
-                              'data:text/plain;charset=utf-8;base64,' + result.data.data[0].content;
-                            link.download = result.data.data[0].name;
-                            document.body.appendChild(link);
-                            link.click();
-                            document.body.removeChild(link);
-                          });
-                      }}
+                      href={
+                        apiEndpoint.replace('contribs-api', 'contribs') + 'component/' + aitem.id
+                      }
                     >
                       <FaDownload className="mr-1" />
                     </a>


### PR DESCRIPTION
Add Structures download and Attachments download columns to MPContribs Explorer table, similar to https://contribs.materialsproject.org/projects/open_catalyst_project

Changes:
- add new CONTRIBS_FILES_DOWNLOAD  ColumnFormat
- add Structures/Attachments download functions in utils/table.tsx

