### PR TITLE
fixed invisible emails in contribs explorer

### DIFF
--- a/src/utils/table.tsx
+++ b/src/utils/table.tsx
@@ -255,11 +255,14 @@ export const initColumns = (columns: Column[], disableRichColumnHeaders?: boolea
       case ColumnFormat.EMAIL:
         c.cell = (row: any) => {
           const rowValue = getRowValueFromSelectorString(c.selector, row);
-          const firstAuthor =
-            //typeof rowValue === 'string' && rowValue.includes(',') ? rowValue.split(',')[0] : '';
-            typeof rowValue === 'string' && rowValue.includes(',')
-              ? rowValue.split(',')[0]
-              : rowValue;
+          if (typeof rowValue === 'string') {
+            const firstAuthor =
+              typeof rowValue === 'string' && rowValue.includes(',')
+                ? rowValue.split(',')[0]
+                : rowValue;
+          } else {
+            const firstAuthor = '';
+          }
           let emailAddressPart = '';
           if (c && c.formatOptions && typeof row[c.formatOptions.emailAddressKey] === 'string') {
             const parts = row[c.formatOptions.emailAddressKey].split(':');

--- a/src/utils/table.tsx
+++ b/src/utils/table.tsx
@@ -256,7 +256,10 @@ export const initColumns = (columns: Column[], disableRichColumnHeaders?: boolea
         c.cell = (row: any) => {
           const rowValue = getRowValueFromSelectorString(c.selector, row);
           const firstAuthor =
-            typeof rowValue === 'string' && rowValue.includes(',') ? rowValue.split(',')[0] : '';
+            //typeof rowValue === 'string' && rowValue.includes(',') ? rowValue.split(',')[0] : '';
+            typeof rowValue === 'string' && rowValue.includes(',')
+              ? rowValue.split(',')[0]
+              : rowValue;
           let emailAddressPart = '';
           if (c && c.formatOptions && typeof row[c.formatOptions.emailAddressKey] === 'string') {
             const parts = row[c.formatOptions.emailAddressKey].split(':');


### PR DESCRIPTION
Fixed issue where not all names under the "Authors" column showed up. turns out the reason for why it was like that was because of the way the email format type was handled in mp-react-components/src/utils/table.tsx under the section case ColumnFormat.EMAIL. Previously, it was putting an empty string as the firstAuthor if there was only one name present instead of the actual first Author so I just changed it to that.