### PR TITLE
update Python 3.7 -> 3.11.13

### DIFF
--- a/.github/workflows/jest_tests.yml
+++ b/.github/workflows/jest_tests.yml
@@ -27,10 +27,10 @@ jobs:
           scope: '@mat-github-ci'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11.13
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11.13
       - uses: actions/cache@v4
         with:
           path: ~/.npm


### PR DESCRIPTION
Addressing the issue in jest_tests.yml:

`Version 3.7 with arch x64 not found Available versions: 3.10.18 (x64) 3.11.13 (x64) 3.12.11 (x64) 3.13.7 (x64) 3.9.23 (x64)`