### PR TITLE
add --max-old-space-size=4096 to NODE_OPTIONS

### DIFF
--- a/.github/workflows/jest_tests.yml
+++ b/.github/workflows/jest_tests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Generate build number
         id:
@@ -22,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 12.x
           registry-url: https://registry.npmjs.org/
           scope: '@mat-github-ci'
         env:


### PR DESCRIPTION
add --max-old-space-size=4096 to NODE_OPTIONS

Address testing issue:
`FATAL ERROR: MarkCompactCollector: young object promotion failed Allocation failed - JavaScript heap out of memory`