### PR TITLE
Fix typo in getDelimiter space/hyphen index comparison

### DIFF
--- a/src/components/data-entry/utils.tsx
+++ b/src/components/data-entry/utils.tsx
@@ -130,7 +130,7 @@ export const getDelimiter = (input: string): RegExp | undefined => {
     space &&
     space.index &&
     (!comma || (comma.index && comma.index > space.index)) &&
-    (!hyphen || (hyphen.index && space.index > space.index))
+    (!hyphen || (hyphen.index && space.index > hyphen.index))
   ) {
     return new RegExp(/\s/);
   } else {


### PR DESCRIPTION
## Summary

When querying ternary phase diagrams, 'Li-Zn-O' and 'Li - Zn - O' produce very different results. I suppose the actual fix is for the user (me) to use the formatting convention suggested by the website, but it seems like a nice thing to have. 

space.index > space.index on line 133 always evaluates to false

Major changes:

`(!hyphen || (hyphen.index && space.index > space.index))` -> `(!hyphen || (hyphen.index && space.index > hyphen.index))`


