### PR TITLE
alphaID validation

### DIFF
--- a/src/components/data-entry/MaterialsInput/utils.tsx
+++ b/src/components/data-entry/MaterialsInput/utils.tsx
@@ -334,15 +334,7 @@ export const validateSmiles = (value: string): string | null => {
  * @returns Validated id string or null
  */
 export const validateMPID = (value: string): string | null => {
-  if (
-    value.match(/mp\-\d/) !== null ||
-    value.match(/mvc\-\d/) !== null ||
-    value.match(/mol\-\d/) !== null
-  ) {
-    return value;
-  } else {
-    return null;
-  }
+  return /^mp-([a-zA-Z]+|\d+)$/.test(value) || /^(mvc|mol)-\d+$/.test(value) ? value : null;
 };
 
 /**


### PR DESCRIPTION
^

Note:
`.match()` only does substring matching, so `mp-1dijsaiod` can go through. 
With `test()`, it will validate entire string. 
