### PR TITLE
add refresh to Link

### DIFF
--- a/src/components/navigation/Navbar/Navbar.tsx
+++ b/src/components/navigation/Navbar/Navbar.tsx
@@ -26,6 +26,7 @@ export interface NavbarItem {
   id?: string;
   header?: string;
   content?: string;
+  refresh?: boolean;
 }
 
 export interface NavbarProps {
@@ -63,6 +64,7 @@ export const Navbar: React.FC<NavbarProps> = ({ items = [], ...otherProps }) => 
         <Link
           className={classNames('navbar-item', item.className)}
           href={item.href || ''}
+          refresh={item.refresh}
           // onClick={() => setActiveMobile(false)}
         >
           {item.icon && <Icon icon={item.icon} />}

--- a/src/components/navigation/NavbarDropdown/NavbarDropdown.tsx
+++ b/src/components/navigation/NavbarDropdown/NavbarDropdown.tsx
@@ -70,6 +70,7 @@ export const NavbarDropdown: React.FC<Props> = (props) => {
                 <Link
                   key={i}
                   href={item.href || ''}
+                  refresh={item.refresh}
                   className={classNames('navbar-item', item.className)}
                 >
                   {item.label}


### PR DESCRIPTION
^

The current Navbar defaults to client-side navigation (refresh=False), which prevents navigation from working correctly in the decomposed mp-ui deployment.

The current `Link` component performs client-side routing using `history.pushState()`. Since this updates the URL without issuing a new HTTP request, the request never reaches Kong and therefore cannot be routed to the appropriate application container.

Fix:
Add support for the refresh option in Navbar links. When `refresh=True`, the browser performs a full page navigation, generating a new HTTP request that passes through Kong and allows the request to be routed to the correct container.